### PR TITLE
Fix potential access on undefined

### DIFF
--- a/packages/zod/src/core/parser/validators/extractIssuesMessages.ts
+++ b/packages/zod/src/core/parser/validators/extractIssuesMessages.ts
@@ -4,6 +4,6 @@ import type { ZodIssue } from 'zod';
 export function extractIssuesMessages() {
   return ((metadata: { $issues: ZodIssue[] }) => {
     const issueMessages = metadata.$issues?.map((issue) => issue.message);
-    return issueMessages.length ? issueMessages : 'Error';
+    return issueMessages?.length ? issueMessages : 'Error';
   }) satisfies RegleRuleDefinitionWithMetadataProcessor<any, any, any>;
 }


### PR DESCRIPTION
This PR might not be necessary depending on what happens with #41 but currently I run into an access of undefined. The type-sig claims `$issues` will never be null but I saw on L6 there's already optional access with `?.` so I am not sure what the intended behaviour is.