### PR TITLE
fix!: fixed spelling errors in docs and rule metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
   - type: textarea
     id: other-info
     attributes:
-      label: Environnement informations
+      label: Environment information
       description: Versions of your packages
       value: |
         - `@regle/x` version:

--- a/docs/.vitepress/theme/custom.scss
+++ b/docs/.vitepress/theme/custom.scss
@@ -378,7 +378,7 @@ h2 + h2 {
   background: var(--icon) no-repeat center / contain;
 }
 
-/* Two slashs */
+/* Two slashes */
 
 .language-twoslash {
   display: none;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -8,7 +8,7 @@
  *
  * Each colors have exact same color scale system with 3 levels of solid
  * colors with different brightness, and 1 soft color.
- * 
+ *
  * - `XXX-1`: The most solid color used mainly for colored text. It must
  *   satisfy the contrast ratio against when used on top of `XXX-soft`.
  *
@@ -28,7 +28,7 @@
  *   custom containers.
  *
  * - `default`: The color used purely for subtle indication without any
- *   special meanings attched to it such as bg color for menu hover state.
+ *   special meanings attatched to it such as bg color for menu hover state.
  *
  * - `brand`: Used for primary brand colors, such as link text, button with
  *   brand theme, etc.

--- a/docs/src/advanced-usage/async-validation.md
+++ b/docs/src/advanced-usage/async-validation.md
@@ -9,12 +9,12 @@ title: Async validations
 
 # Async validation
 
-A common pattern in forms is to asynchronously check for a value on the serveride.
-Async rules can perform this tasks, and they update the `$pending` state whenever invoked.
+A common pattern in forms is to asynchronously check for a value on the server side.
+Async rules can perform these tasks, and they update the `$pending` state whenever invoked.
 
 
 :::tip
-By default, all async rules will have a debounce of `200ms`. It can be overriden with the `$debounce` modifier.
+By default, all async rules will be debounced by `200ms`. It can be overriden with the `$debounce` modifier.
 :::
 
 ## Inline Async rule
@@ -30,7 +30,7 @@ const myAsyncRule = async (value: Maybe<number>) => {
 }
 ```
 
-If your rule doesn't use `async await` syntax, but still returns a `Promise`, you have to use the `withAsync` helper when using your rule in your form. Otherwise Regle can't know it's an async rule.
+If your rule doesn't use `async await` syntax, but still returns a `Promise`, you have to use the `withAsync` helper when using your rule in your form. Otherwise, Regle can't know it's an async rule.
 
 
 ## Async using `createRule`
@@ -56,7 +56,7 @@ Every time you update the `$value` of the field using an async rule, the `$pendi
 This can be used to display a loading icon and a custom message indicating that an operation is taking time.
 
 
-## Full exemple
+## Full example
 
 ```vue twoslash [App.vue]
 <template>

--- a/docs/src/advanced-usage/scoped-validation.md
+++ b/docs/src/advanced-usage/scoped-validation.md
@@ -132,7 +132,7 @@ Each scope can collect a specific namespace. Giving a namespace name will collec
 
 The namespace can be reactive, so it will update every time it changes.
 
-In this exemple, only the components using the same scope and same namespace will be collected.
+In this example, only the components using the same scope and namespace will be collected.
 
 :::code-group
 ```vue twoslash [Parent.vue]
@@ -241,7 +241,7 @@ const { useScopedRegle, useCollectScope } = createScopedUseRegle({customStore: m
 
 `useScopedRegle` also returns two methods: `dispose` and `register`.
 
-You can then programmaticaly handle if your component is collected from inside.
+You can then programmatically handle if your component is collected from inside.
 
 ```vue twoslash
 <script setup lang='ts'>

--- a/docs/src/advanced-usage/variants.md
+++ b/docs/src/advanced-usage/variants.md
@@ -71,13 +71,13 @@ const {r$} = useRegle(state, () => {
 
 ## `narrowVariant`
 
-In your form, you'll need to use type narrowing to access your fields status somehow. 
+In your form, you'll need to use type narrowing to access your field status somehow. 
 
 For this you'll have to discriminate the `$fields` depending on value. As the status uses deeply nested properties, this will not be possible with a standard guard `if (value === "EMAIL")`.
 
 In your template or script, you can use Regle's `narrowVariant` helper to narrow the fields to the value.
 
-Let's take the previous exemple again:
+Let's take the previous example again:
 
 ```vue twoslash
 <template>
@@ -220,7 +220,7 @@ const {r$} = useExample();
 
 A use case is also to have a narrowed **Ref** ready to be used and isn't tied to a block scope. Like in the root of a script setup component where you're sure only one variant is possible.
 
-Having a `variantToRef` helper prevent you from creating custom `computed` methods, which would make you lose the `v-model` compabilities of the `.$value`.
+Having a `variantToRef` helper prevents you from creating custom `computed` methods, which would make you lose the `v-model` compatibilities of the `.$value`.
 
 The **ref** will be reactive and already typed as the variant you defined, while still needing to be checked for nullish.
 

--- a/docs/src/blog/regle-1.1.md
+++ b/docs/src/blog/regle-1.1.md
@@ -130,7 +130,7 @@ type FormRequest = InferSafeOutput<typeof r$>;
 
 ## 🦸 Support Zod 4 <span data-title="zod"></span> 
 
-[Zod 4 is currently in beta](https://v4.zod.dev/v4), and Regle officialy supports it.
+[Zod 4 is currently in beta](https://v4.zod.dev/v4), and Regle officially supports it.
 
 Some bugs on Zod side may persists, but breaking changes are minimal.  
 Nothing is to change on Regle side.

--- a/docs/src/core-concepts/displaying-errors.md
+++ b/docs/src/core-concepts/displaying-errors.md
@@ -29,7 +29,7 @@ Result:
 ## Display custom error messages
 
 To display custom error messages, you can use the [withMessage](/core-concepts/rules/rule-wrappers#withmessage) helper.   
-You have access to additional data like paramaters or rule status to write your message.
+You have access to additional data like parameters or rule status to write your message.
 
 :::tip
 If you have to write a lot of forms in your apps, consider using [defineRegleConfig](/advanced-usage/global-config#replace-built-in-rules-messages) instead.

--- a/docs/src/core-concepts/index.md
+++ b/docs/src/core-concepts/index.md
@@ -142,7 +142,7 @@ const { r$ } = useRegle(state, {
 
 If you’ve used Vuelidate before, useRegle behaves similarly to `v$`.
 
-`r$` is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display informations.
+`r$` is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display information.
 
 You can find all the [available properties here](/core-concepts/validation-properties)
 
@@ -161,4 +161,3 @@ r$.$fields.
 </script>
 
 ```
-

--- a/docs/src/core-concepts/rules/built-in-rules.md
+++ b/docs/src/core-concepts/rules/built-in-rules.md
@@ -474,7 +474,7 @@ const { r$ } = useRegle({ count: 0 }, {
 
 ## `nativeEnum`
 
-Validate against a native Typescript enum value. Similiar to Zod's `nativeEnum`
+Validate against a native Typescript enum value. Similar to Zod's `nativeEnum`
 
 ```ts twoslash
 import {useRegle} from '@regle/core';
@@ -660,4 +660,3 @@ const { r$ } = useRegle({ bestUrl: '' }, {
   bestUrl: { url },
 })
 ```
-

--- a/docs/src/core-concepts/rules/reusable-rules.md
+++ b/docs/src/core-concepts/rules/reusable-rules.md
@@ -207,7 +207,7 @@ useRegle(state, rules);
 
 The `active` property option is a field that will provide the rule an `on/off` behaviour.
 
-Some rules have conditionnal validation properties, such as `requiredIf` or any rule using `applyIf`.
+Some rules have conditional validation properties, such as `requiredIf` or any rule using `applyIf`.
 This property allows you to declare the active state of the rule.
 
 It will then be exposed in the `$active` rule property and be used to reflect the validation to your user.

--- a/docs/src/core-concepts/type-safe-output.md
+++ b/docs/src/core-concepts/type-safe-output.md
@@ -53,7 +53,7 @@ async function submit() {
 
 ### `InferSafeOutput`
 
-You can also staticly infer the safe output from any `r$` instance.
+You can also statically infer the safe output from any `r$` instance.
 
 
 ```ts twoslash
@@ -75,4 +75,3 @@ const { r$ } = useRegle(form, {
 type FormRequest = InferSafeOutput<typeof r$>;
 //    ^?
 ```
-

--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -30,7 +30,7 @@ const { r$ } = useRegle({ email: '' }, {
 
 <br/>
 
-From `r$` , you can build any UI around your forms fields, like displaying error messages, handling **dirty** fields, reseting and validating values etc...
+From `r$` , you can build any UI around your forms fields, like displaying error messages, handling **dirty** fields, resetting and validating values etc...
 
 
 ## Complete example

--- a/docs/src/introduction/installation.md
+++ b/docs/src/introduction/installation.md
@@ -19,7 +19,7 @@ Optional
 - [Pinia](https://pinia.vuejs.org/) <span data-title="pinia"></span> 
   - Pinia  `2.2.5+`
 
-Schema libraires: [Docs](/integrations/schemas-libraries)
+Schema libraries: [Docs](/integrations/schemas-libraries)
 
 - [Zod](https://zod.dev/) <span data-title="zod"></span> `3.24+`. 
 - [Valibot](https://valibot.dev/) <span data-title="valibot"></span> `1+`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@
 # Regle
 
 
-Regle \ʁɛɡl\ (French word for 'rule' ) is a Typescript-first model-based validation library for Vue 3.
+Regle \ʁɛɡl\ (French word for 'rule') is a Typescript-first model-based validation library for Vue 3.
 It's heavily inspired by Vuelidate.
 
 

--- a/packages/core/src/core/createRule/unwrapRuleParameters.ts
+++ b/packages/core/src/core/createRule/unwrapRuleParameters.ts
@@ -2,7 +2,7 @@ import { computed, isRef, toRef, toValue, unref, type MaybeRefOrGetter } from 'v
 
 /**
  * Returns a clean list of parameters
- * Removing Ref and executing function to return the unwraped value
+ * Removing Ref and executing function to return the unwrapped value
  */
 export function unwrapRuleParameters<TParams extends any[]>(params: MaybeRefOrGetter[]): TParams {
   try {
@@ -14,7 +14,7 @@ export function unwrapRuleParameters<TParams extends any[]>(params: MaybeRefOrGe
 
 /**
  * Returns a clean list of parameters
- * Removing Ref and executing function to return the unwraped value
+ * Removing Ref and executing function to return the unwrapped value
  */
 export function createReactiveParams<TParams extends any[]>(params: MaybeRefOrGetter[]): TParams {
   return params.map((param) => {
@@ -28,7 +28,7 @@ export function createReactiveParams<TParams extends any[]>(params: MaybeRefOrGe
 }
 
 /**
- * Due to `function.length` not returning default parameters, it need to parse the func.toString()
+ * Due to `function.length` not returning default parameters, it needed to parse the func.toString()
  */
 export function getFunctionParametersLength(func: Function): number {
   const funcStr = func.toString();

--- a/packages/core/src/core/createScopedUseRegle/useScopedRegle.ts
+++ b/packages/core/src/core/createScopedUseRegle/useScopedRegle.ts
@@ -22,7 +22,7 @@ export function createUseScopedRegleComposable<
 
     const computedNamespace = computed(() => toValue(namespace));
 
-    // Keep order while avoiding conflits of ids
+    // Keep order while avoiding conflicting ids
     const $id = ref(`${Object.keys(instances.value).length + 1}-${randomId()}`);
 
     const instanceName = computed(() => {

--- a/packages/core/src/core/createVariant.ts
+++ b/packages/core/src/core/createVariant.ts
@@ -48,15 +48,15 @@ export function createVariant<
   TVariants extends VariantTuple<JoinDiscriminatedUnions<TForm>, TDiscriminant>,
 >(
   root: MaybeRefOrGetter<TForm> | DeepReactiveState<TForm>,
-  disciminantKey: TDiscriminant,
+  discriminantKey: TDiscriminant,
   variants: [...TVariants]
 ): Ref<TVariants[number]> {
-  const watchableRoot = computed(() => (toValue(root) as JoinDiscriminatedUnions<TForm>)[disciminantKey]);
+  const watchableRoot = computed(() => (toValue(root) as JoinDiscriminatedUnions<TForm>)[discriminantKey]);
 
   const computedRules = computed(() => {
     const selectedVariant = variants.find((variant) => {
-      if ((variant as any)[disciminantKey] && 'literal' in (variant as any)[disciminantKey]) {
-        const literalRule = variant[disciminantKey]['literal'];
+      if ((variant as any)[discriminantKey] && 'literal' in (variant as any)[discriminantKey]) {
+        const literalRule = variant[discriminantKey]['literal'];
         if (isRuleDef(literalRule)) {
           return unref(literalRule._params?.[0]) === watchableRoot.value;
         }
@@ -68,7 +68,7 @@ export function createVariant<
     } else {
       const anyDiscriminantRules = variants.find(
         (variant) =>
-          isObject(variant[disciminantKey]) && !Object.keys(variant[disciminantKey]).some((key) => key === 'literal')
+          isObject(variant[discriminantKey]) && !Object.keys(variant[discriminantKey]).some((key) => key === 'literal')
       );
 
       if (anyDiscriminantRules) {

--- a/packages/core/src/core/defaultValidators.ts
+++ b/packages/core/src/core/defaultValidators.ts
@@ -33,7 +33,7 @@ export type DefaultValidators = {
       }
     | {
         $valid: false;
-        error: 'value-or-paramater-not-a-date';
+        error: 'value-or-parameter-not-a-date';
       }
   >;
   dateBefore: RegleRuleWithParamsDefinition<
@@ -47,7 +47,7 @@ export type DefaultValidators = {
       }
     | {
         $valid: false;
-        error: 'value-or-paramater-not-a-date';
+        error: 'value-or-parameter-not-a-date';
       }
   >;
   dateBetween: RegleRuleWithParamsDefinition<

--- a/packages/core/src/core/defineRegleConfig.ts
+++ b/packages/core/src/core/defineRegleConfig.ts
@@ -6,7 +6,7 @@ import { merge } from '../../../shared';
 
 /**
  * Define a global regle configuration, where you can:
- * - Customize buil-in rules messages
+ * - Customize built-in rules messages
  * - Add your custom rules
  * - Define global modifiers
  * - Define shortcuts

--- a/packages/core/src/core/mergeRegles.ts
+++ b/packages/core/src/core/mergeRegles.ts
@@ -18,7 +18,7 @@ export type MergedRegles<
   RegleCommonStatus,
   '$value' | '$silentValue' | '$errors' | '$silentErrors' | '$name' | '$unwatch' | '$watch'
 > & {
-  /** Dictionnay of merged Regle instances and their properties  */
+  /** Map of merged Regle instances and their properties  */
   readonly $instances: { [K in keyof TRegles]: TRegles[K] };
   /** A reference to the original validated model. It can be used to bind your form with v-model.*/
   $value: TValue;

--- a/packages/core/src/core/useRegle/root/createReactiveFieldStatus.ts
+++ b/packages/core/src/core/useRegle/root/createReactiveFieldStatus.ts
@@ -598,7 +598,7 @@ export function createReactiveFieldStatus({
       return state.value;
     }
     if (filterNullishValues) {
-      // Differenciate untouched empty values from dirty empty ones
+      // Differentiate untouched empty values from dirty empty ones
       return { _null: true };
     }
     return null;

--- a/packages/core/src/core/useRegle/useErrors.ts
+++ b/packages/core/src/core/useRegle/useErrors.ts
@@ -78,17 +78,17 @@ export function flatErrors(
     const selfErrors = includePath
       ? (errors.$self?.map((err) => ({ error: err, path: '' })) ?? [])
       : (errors.$self ?? []);
-    const eachErrors = errors.$each?.map((err) => interateErrors(err, includePath)) ?? [];
+    const eachErrors = errors.$each?.map((err) => iterateErrors(err, includePath)) ?? [];
     return selfErrors?.concat(eachErrors.flat());
   } else {
     // Nested errors
     return Object.entries(errors)
-      .map(([key, value]) => interateErrors(value, includePath, [key]))
+      .map(([key, value]) => iterateErrors(value, includePath, [key]))
       .flat();
   }
 }
 
-function interateErrors(
+function iterateErrors(
   errors: $InternalRegleErrors,
   includePath = false,
   _path?: string[]
@@ -112,12 +112,12 @@ function interateErrors(
       ? (errors.$self?.map((err) => ({ error: err, path: path.join('.') })) ?? [])
       : (errors.$self ?? []);
     const eachErrors =
-      errors.$each?.map((err, index) => interateErrors(err, includePath, path?.concat(index.toString()))) ?? [];
+      errors.$each?.map((err, index) => iterateErrors(err, includePath, path?.concat(index.toString()))) ?? [];
     return selfErrors?.concat(eachErrors.flat());
   } else {
     // Nested errors
     return Object.entries(errors)
-      .map(([key, value]) => interateErrors(value, includePath, path?.concat(key)))
+      .map(([key, value]) => iterateErrors(value, includePath, path?.concat(key)))
       .flat();
   }
 }

--- a/packages/core/src/core/useRegle/useErrors.ts
+++ b/packages/core/src/core/useRegle/useErrors.ts
@@ -50,7 +50,7 @@ function isCollectionError(errors: $InternalRegleErrors): errors is $InternalReg
 }
 
 /**
- * Converts an nested $errors object to a flat array of string errors
+ * Converts a nested $errors object to a flat array of string errors
  *
  * Can also flatten to an array containing the path of each error with the options.includePath
  */

--- a/packages/core/src/types/core/modifiers.types.ts
+++ b/packages/core/src/types/core/modifiers.types.ts
@@ -20,7 +20,7 @@ export interface RegleBehaviourOptions {
    */
   lazy?: boolean | undefined;
   /**
-   * Automaticaly set the dirty set without the need of `$value` or `$touch`
+   * Automatically set the dirty set without the need of `$value` or `$touch`
    * @default true
    *
    * @default false if rewardEarly is true
@@ -33,7 +33,7 @@ export interface RegleBehaviourOptions {
    */
   rewardEarly?: boolean | undefined;
   /**
-   * Define wether or not the external errors should be cleared when updating a field
+   * Define whether the external errors should be cleared when updating a field
    * @default true
    *
    */
@@ -77,32 +77,32 @@ export type ShortcutCommonFn<T extends Record<string, any>> = {
 
 export type RegleShortcutDefinition<TCustomRules extends Record<string, any> = {}> = {
   /**
-   * Allow you to customize the properties of every single field
+   * Allow you to customize the properties for every field
    */
   fields?: ShortcutCommonFn<RegleFieldStatus<any, Partial<TCustomRules> & Partial<DefaultValidators>>>;
   /**
-   * Allow you to customize the properties of every parent of a nested object
+   * Allow you to customize the properties for every parent of a nested object
    */
   nested?: ShortcutCommonFn<
     RegleStatus<Record<string, any>, ReglePartialRuleTree<any, Partial<TCustomRules> & Partial<DefaultValidators>>>
   >;
   /**
-   * Allow you to customize the properties of every parent of a collection
+   * Allow you to customize the properties for every parent of a collection
    */
   collections?: ShortcutCommonFn<RegleCollectionStatus<any[], Partial<TCustomRules> & Partial<DefaultValidators>>>;
 };
 
 export type $InternalRegleShortcutDefinition = {
   /**
-   * Allow you to customize the properties of every single field
+   * Allow you to customize the properties for every field
    */
   fields?: ShortcutCommonFn<Record<string, any>>;
   /**
-   * Allow you to customize the properties of every parent of a nested object
+   * Allow you to customize the properties for every parent of a nested object
    */
   nested?: ShortcutCommonFn<$InternalRegleStatus>;
   /**
-   * Allow you to customize the properties of every parent of a collection
+   * Allow you to customize the properties for every parent of a collection
    */
   collections?: ShortcutCommonFn<$InternalRegleCollectionStatus>;
 };

--- a/packages/core/src/types/core/reset.types.ts
+++ b/packages/core/src/types/core/reset.types.ts
@@ -10,7 +10,7 @@ export type ResetOptions<TState extends unknown> = RequireOneOrNone<
     toInitialState?: boolean;
     /**
      * Reset validation status and reset form state to the given state
-     * Also set the new state as new initial state.
+     * Also set the new state as the initial state.
      */
     toState?: TState | (() => TState);
     /**

--- a/packages/core/src/types/core/useRegle.types.ts
+++ b/packages/core/src/types/core/useRegle.types.ts
@@ -18,7 +18,7 @@ export type Regle<
   TAdditionalReturnProperties extends Record<string, any> = {},
 > = {
   /**
-   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display informations.
+   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display information.
    *
    * To see the list of properties: {@link https://reglejs.dev/core-concepts/validation-properties}
    */
@@ -32,7 +32,7 @@ export type RegleSingleField<
   TAdditionalReturnProperties extends Record<string, any> = {},
 > = {
   /**
-   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display informations.
+   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display information.
    *
    * To see the list of properties: {@link https://reglejs.dev/core-concepts/validation-properties}
    */

--- a/packages/core/src/types/rules/rule.definition.type.ts
+++ b/packages/core/src/types/rules/rule.definition.type.ts
@@ -109,7 +109,7 @@ type DefaultMetadataProperties = DefaultMetadataPropertiesCommon & {
 };
 
 /**
- * Will be used to consumme metadata on related helpers and rule status
+ * Will be used to consume metadata on related helpers and rule status
  */
 export type RegleRuleMetadataConsumer<
   TValue extends any,
@@ -128,7 +128,7 @@ export type RegleRuleMetadataConsumer<
     : {});
 
 /**
- * Will be used to consumme metadata on related helpers and rule status
+ * Will be used to consume metadata on related helpers and rule status
  */
 export type PossibleRegleRuleMetadataConsumer<TValue> = { $value: Maybe<TValue> } & DefaultMetadataProperties & {
     $params?: [...any[]];
@@ -170,7 +170,7 @@ export type RegleRuleRawInput<
   tooltip?: any;
 };
 /**
- * Process the type of a created rule with `createRule`.
+ * Process the type of created rule with `createRule`.
  * For a rule with params it will return a function
  * Otherwise it will return the rule definition
  */

--- a/packages/core/src/types/rules/rule.internal.types.ts
+++ b/packages/core/src/types/rules/rule.internal.types.ts
@@ -3,7 +3,7 @@ import type { PossibleRegleRuleMetadataConsumer, RegleRuleMetadataDefinition } f
 import type { RegleUniversalParams } from './rule.params.types';
 
 /**
- * Internal definition of the rule, can be used to reset or patch the rule
+ * Internal definition of the rule, this can be used to reset or patch the rule
  */
 export interface RegleInternalRuleDefs<
   TValue extends any = any,

--- a/packages/core/src/types/utils/object.types.ts
+++ b/packages/core/src/types/utils/object.types.ts
@@ -22,7 +22,7 @@ export type RestoreOptionalProperties<TObject extends Record<string, any>> = {
 type GetMaybeObjectValue<O extends Record<string, any>, K extends string> = K extends keyof O ? O[K] : undefined;
 
 /**
- * Combine all unions values to be able to get even the normally "never" values, act as an intersection type
+ * Combine all union values to be able to get even the normally "never" values, act as an intersection type
  */
 type RetrieveUnionUnknownValues<T extends readonly any[], TKeys extends string> = T extends [
   infer F extends Record<string, any>,
@@ -43,14 +43,14 @@ type RetrieveUnionUnknownValues<T extends readonly any[], TKeys extends string> 
   : [];
 
 /**
- * Get all possible keys from an union, even the ones present only on one union
+ * Get all possible keys from a union, even the ones present only on one union
  */
 type RetrieveUnionUnknownKeysOf<T extends readonly any[]> = T extends [infer F, ...infer R]
   ? [keyof F, ...RetrieveUnionUnknownKeysOf<R>]
   : [];
 
 /**
- * Transforms an union and apply undefined values to non-present keys to support intersection
+ * Transforms a union and apply undefined values to non-present keys to support intersection
  */
 type NormalizeUnion<TUnion> = RetrieveUnionUnknownValues<
   NonNullable<UnionToTuple<TUnion>>,
@@ -58,7 +58,7 @@ type NormalizeUnion<TUnion> = RetrieveUnionUnknownValues<
 >[number];
 
 /**
- * Combine all members of an union type, merging types for each keys, and keeping loose types
+ * Combine all members of a union type, merging types for each key, and keeping loose types
  */
 export type JoinDiscriminatedUnions<TUnion extends unknown> =
   isRecordLiteral<TUnion> extends true

--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -5,7 +5,7 @@
 # Regle
 
 
-Regle \ʁɛɡl\ (French word for 'rule' ) is a Typescript-first model-based validation library for Vue 3.
+Regle \ʁɛɡl\ (French word for 'rule') is a Typescript-first model-based validation library for Vue 3.
 It's heavily inspired by Vuelidate.
 
 
@@ -37,4 +37,3 @@ npx nuxi module add regle
 - 🦸‍♂️ [Zod](https://zod.dev/) support
 - 🤖 [Valibot](https://valibot.dev/) support
 - 🪶 Light(~7kb gzip) and 0 dependencies
-

--- a/packages/nuxt/test/fixtures/pages/index.vue
+++ b/packages/nuxt/test/fixtures/pages/index.vue
@@ -46,7 +46,7 @@
                 <option disabled value="undefined" selected>Select an event</option>
                 <option value="Corporate">Corporate event</option>
                 <option value="Wedding">Wedding</option>
-                <option value="Borthday">Birthday</option>
+                <option value="Birthday">Birthday</option>
                 <option value="Other">Other</option>
               </select>
               <FieldError :errors="r$.$fields.eventType.$errors" />

--- a/packages/rules/README.md
+++ b/packages/rules/README.md
@@ -5,7 +5,7 @@
 # Regle
 
 
-Regle \ʁɛɡl\ (French word for 'rule' ) is a Typescript-first model-based validation library for Vue 3.
+Regle \ʁɛɡl\ (French word for 'rule') is a Typescript-first model-based validation library for Vue 3.
 It's heavily inspired by Vuelidate.
 
 

--- a/packages/rules/src/helpers/tests/withMessage.spec.ts
+++ b/packages/rules/src/helpers/tests/withMessage.spec.ts
@@ -229,7 +229,7 @@ describe('withMessage helper', () => {
     );
 
     withMessage(dateBefore(new Date()), ({ error }) => {
-      expectTypeOf(error).toEqualTypeOf<'date-not-before' | 'value-or-paramater-not-a-date' | undefined>();
+      expectTypeOf(error).toEqualTypeOf<'date-not-before' | 'value-or-parameter-not-a-date' | undefined>();
       return '';
     });
 

--- a/packages/rules/src/helpers/tests/withMessage.spec.ts
+++ b/packages/rules/src/helpers/tests/withMessage.spec.ts
@@ -72,7 +72,7 @@ describe('withMessage helper', () => {
     expect(vm.r$.$errors.firstName).toStrictEqual(['Required']);
   });
 
-  it('should handle overriden rules with params', async () => {
+  it('should handle overridden rules with params', async () => {
     vm.r$.$value.testOverride = 'foo';
     await nextTick();
     expect(vm.r$.$fields.testOverride.$errors).toStrictEqual(['Test override: 6']);
@@ -163,7 +163,7 @@ describe('withMessage helper', () => {
     // @ts-expect-error no message argument ❌
     withMessage((value) => true);
 
-    // @ts-expect-error incorrrect return type ❌
+    // @ts-expect-error incorrect return type ❌
     withMessage((value) => {}, 'Message');
 
     // Correct type with async value returning metadata

--- a/packages/rules/src/helpers/tests/withMessage.spec.ts
+++ b/packages/rules/src/helpers/tests/withMessage.spec.ts
@@ -20,7 +20,7 @@ describe('withMessage helper', () => {
         testOverride: '',
       });
 
-      const overridenRule = withMessage(minLength, ({ $params: [min] }) => `Test override: ${min}`);
+      const overriddenRule = withMessage(minLength, ({ $params: [min] }) => `Test override: ${min}`);
 
       return useRegle(form, () => ({
         email: {
@@ -43,7 +43,7 @@ describe('withMessage helper', () => {
           ),
         },
         testOverride: {
-          foo: overridenRule(6),
+          foo: overriddenRule(6),
         },
       }));
     },

--- a/packages/rules/src/rules/dateAfter.ts
+++ b/packages/rules/src/rules/dateAfter.ts
@@ -19,7 +19,7 @@ export const dateAfter: RegleRuleWithParamsDefinition<
     }
   | {
       $valid: false;
-      error: 'value-or-paramater-not-a-date';
+      error: 'value-or-parameter-not-a-date';
     }
 > = createRule({
   type: 'dateAfter',
@@ -32,12 +32,12 @@ export const dateAfter: RegleRuleWithParamsDefinition<
         }
         return { $valid: false, error: 'date-not-after' as const };
       }
-      return { $valid: false, error: 'value-or-paramater-not-a-date' as const };
+      return { $valid: false, error: 'value-or-parameter-not-a-date' as const };
     }
     return true;
   },
   message: ({ $params: [after], error }) => {
-    if (error === 'value-or-paramater-not-a-date') {
+    if (error === 'value-or-parameter-not-a-date') {
       return 'The values must be dates';
     }
     return `The date must be after ${formatLocaleDate(after)}`;

--- a/packages/rules/src/rules/dateBefore.ts
+++ b/packages/rules/src/rules/dateBefore.ts
@@ -19,7 +19,7 @@ export const dateBefore: RegleRuleWithParamsDefinition<
     }
   | {
       $valid: false;
-      error: 'value-or-paramater-not-a-date';
+      error: 'value-or-parameter-not-a-date';
     }
 > = createRule({
   type: 'dateBefore',
@@ -32,12 +32,12 @@ export const dateBefore: RegleRuleWithParamsDefinition<
         }
         return { $valid: false, error: 'date-not-before' as const };
       }
-      return { $valid: false, error: 'value-or-paramater-not-a-date' as const };
+      return { $valid: false, error: 'value-or-parameter-not-a-date' as const };
     }
     return true;
   },
   message: ({ $params: [before], error }) => {
-    if (error === 'value-or-paramater-not-a-date') {
+    if (error === 'value-or-parameter-not-a-date') {
       return 'The values must be dates';
     }
 

--- a/packages/rules/src/rules/maxLength.ts
+++ b/packages/rules/src/rules/maxLength.ts
@@ -7,7 +7,7 @@ import type { CommonComparisonOptions } from '@regle/core';
  * Requires the input value to have a maximum specified length, inclusive. Works with arrays, objects and strings.
  *
  * @param max - the maximum length
- * @param options - comparision options
+ * @param options - comparison options
  */
 export const maxLength: RegleRuleWithParamsDefinition<
   string | any[] | Record<PropertyKey, any>,

--- a/packages/rules/src/rules/maxValue.ts
+++ b/packages/rules/src/rules/maxValue.ts
@@ -7,7 +7,7 @@ import type { CommonComparisonOptions } from '@regle/core';
  * Requires a field to have a specified maximum numeric value.
  *
  * @param max - the maximum value
- * @param options - comparision options
+ * @param options - comparison options
  */
 export const maxValue: RegleRuleWithParamsDefinition<
   number,

--- a/packages/rules/src/rules/minLength.ts
+++ b/packages/rules/src/rules/minLength.ts
@@ -7,7 +7,7 @@ import type { CommonComparisonOptions } from '@regle/core';
  * Requires the input value to have a minimum specified length, inclusive. Works with arrays, objects and strings.
  *
  * @param min - the minimum value
- * @param options - comparision options
+ * @param options - comparison options
  */
 export const minLength: RegleRuleWithParamsDefinition<
   string | any[] | Record<PropertyKey, any>,

--- a/packages/rules/src/rules/minValue.ts
+++ b/packages/rules/src/rules/minValue.ts
@@ -7,7 +7,7 @@ import type { CommonComparisonOptions } from '@regle/core';
  * Requires a field to have a specified minimum numeric value.
  *
  * @param count - the minimum count
- * @param options - comparision options
+ * @param options - comparison options
  */
 export const minValue: RegleRuleWithParamsDefinition<
   number,

--- a/packages/rules/src/rules/regex.ts
+++ b/packages/rules/src/rules/regex.ts
@@ -10,8 +10,8 @@ export const regex: RegleRuleWithParamsDefinition<string | number, [regexp: RegE
     type: 'regex',
     validator(value: Maybe<string | number>, regexp: RegExp | RegExp[]) {
       if (isFilled(value)) {
-        const filteredRegxp = Array.isArray(regexp) ? regexp : [regexp];
-        return matchRegex(value, ...filteredRegxp);
+        const filteredRegexp = Array.isArray(regexp) ? regexp : [regexp];
+        return matchRegex(value, ...filteredRegexp);
       }
       return true;
     },

--- a/packages/rules/src/rules/startsWith.ts
+++ b/packages/rules/src/rules/startsWith.ts
@@ -5,7 +5,7 @@ import { isFilled } from '../helpers';
 /**
  * Checks if the string starts with the specified substring.
  *
- * @private part - the vlaue the field must start with
+ * @private part - the value the field must start with
  */
 export const startsWith: RegleRuleWithParamsDefinition<string, [part: Maybe<string>], false, boolean> = createRule({
   type: 'startsWith',

--- a/packages/rules/src/rules/tests/contains.spec.ts
+++ b/packages/rules/src/rules/tests/contains.spec.ts
@@ -17,7 +17,7 @@ describe('contains validator', () => {
     expect(contains('any').exec(undefined)).toBe(true);
   });
 
-  it('should validate a value containing paremeter', () => {
+  it('should validate a value containing parameter', () => {
     expect(contains('ir').exec('first')).toBe(true);
   });
 });

--- a/packages/rules/src/rules/tests/dateAfter.spec.ts
+++ b/packages/rules/src/rules/tests/dateAfter.spec.ts
@@ -29,7 +29,7 @@ describe('dateAfter validator', () => {
     expect(dateAfter(new Date(2013)).exec(new Date(2012))).toBe(false);
   });
 
-  it('should not validate an identic date', () => {
+  it('should not validate an identical date', () => {
     expect(dateAfter(new Date(2013)).exec(new Date(2013))).toBe(false);
   });
 });

--- a/packages/rules/src/rules/tests/dateBefore.spec.ts
+++ b/packages/rules/src/rules/tests/dateBefore.spec.ts
@@ -41,7 +41,7 @@ describe('dateBefore validator', () => {
     expect(dateBefore(new Date(2013)).exec(new Date(2014))).toBe(false);
   });
 
-  it('should not validate an identic date', () => {
+  it('should not validate an identical date', () => {
     expect(dateBefore(new Date(2013)).exec(new Date(2013))).toBe(false);
   });
 });

--- a/packages/rules/src/rules/tests/dateBetween.spec.ts
+++ b/packages/rules/src/rules/tests/dateBetween.spec.ts
@@ -29,7 +29,7 @@ describe('dateBetween validator', () => {
     expect(dateBetween(new Date(2013), new Date(2015)).exec(new Date(2012))).toBe(false);
   });
 
-  it('should not validate an identic date', () => {
+  it('should not validate an identical date', () => {
     expect(dateBetween(new Date(2013), new Date(2015)).exec(new Date(2013))).toBe(false);
   });
 });

--- a/packages/rules/src/rules/tests/endsWith.spec.ts
+++ b/packages/rules/src/rules/tests/endsWith.spec.ts
@@ -17,7 +17,7 @@ describe('endsWith validator', () => {
     expect(endsWith('any').exec(undefined)).toBe(true);
   });
 
-  it('should validate a value containing paremeter', () => {
+  it('should validate a value containing parameter', () => {
     expect(endsWith('st').exec('first')).toBe(true);
   });
 });

--- a/packages/rules/src/rules/tests/minValue.spec.ts
+++ b/packages/rules/src/rules/tests/minValue.spec.ts
@@ -5,7 +5,7 @@ describe('minValue validator', () => {
     expect(minValue(5).exec(5)).toBe(true);
   });
 
-  it('should not validate min numbe without allowEqual', () => {
+  it('should not validate min number without allowEqual', () => {
     expect(minValue(5, { allowEqual: false }).exec(5)).toBe(false);
   });
 

--- a/packages/rules/src/rules/tests/nativeEnum.spec.ts
+++ b/packages/rules/src/rules/tests/nativeEnum.spec.ts
@@ -11,7 +11,7 @@ const Position = {
 } as const;
 
 describe('nativeEnum validator', () => {
-  it('should not validate unvalid value', () => {
+  it('should not validate invalid value', () => {
     expect(nativeEnum(Food).exec(5)).toBe(false);
   });
 

--- a/packages/rules/src/rules/tests/oneOf.spec.ts
+++ b/packages/rules/src/rules/tests/oneOf.spec.ts
@@ -1,7 +1,7 @@
 import { oneOf } from '../oneOf';
 
 describe('oneOf validator', () => {
-  it('should not validate unvalid value', () => {
+  it('should not validate invalid value', () => {
     expect(oneOf(['One', 'Two']).exec(5)).toBe(false);
   });
 

--- a/packages/rules/src/rules/tests/startsWith.spec.ts
+++ b/packages/rules/src/rules/tests/startsWith.spec.ts
@@ -17,7 +17,7 @@ describe('startsWith validator', () => {
     expect(startsWith('any').exec(undefined)).toBe(true);
   });
 
-  it('should validate a value containing paremeter', () => {
+  it('should validate a value containing parameter', () => {
     expect(startsWith('fir').exec('first')).toBe(true);
   });
 });

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -5,7 +5,7 @@
 # Regle
 
 
-Regle \ʁɛɡl\ (French word for 'rule' ) is a Typescript-first model-based validation library for Vue 3.
+Regle \ʁɛɡl\ (French word for 'rule') is a Typescript-first model-based validation library for Vue 3.
 It's heavily inspired by Vuelidate.
 
 ## 📚 Documentation

--- a/packages/schemas/src/types/core.types.ts
+++ b/packages/schemas/src/types/core.types.ts
@@ -18,7 +18,7 @@ export interface RegleSchema<
   TShortcuts extends RegleShortcutDefinition = {},
 > {
   /**
-   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display informations.
+   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display information.
    *
    * To see the list of properties: {@link https://reglejs.dev/core-concepts/validation-properties}
    */
@@ -31,7 +31,7 @@ export interface RegleSingleFieldSchema<
   TShortcuts extends RegleShortcutDefinition = {},
 > {
   /**
-   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display informations.
+   * r$ is a reactive object containing the values, errors, dirty state and all the necessary validations properties you'll need to display information.
    *
    * To see the list of properties: {@link https://reglejs.dev/core-concepts/validation-properties}
    */
@@ -158,7 +158,7 @@ export type RegleSchemaCollectionStatus<
   TState extends any[],
   TShortcuts extends RegleShortcutDefinition = {},
 > = Omit<RegleSchemaFieldStatus<TSchema, TState, TShortcuts>, '$errors' | '$silentErrors' | '$validate'> & {
-  /** Collection of status of every item in your collection. Each item will be a field you can access, or map on it to display your elements. */
+  /** Collection of status for every item in your collection. Each item will be a field you can access or iterate to display your elements. */
   readonly $each: Array<InferRegleSchemaStatusType<NonNullable<TSchema>, ArrayElement<TState>, TShortcuts>>;
   /** Represents the status of the collection itself. You can have validation rules on the array like minLength, this field represents the isolated status of the collection. */
   readonly $self: RegleSchemaFieldStatus<TSchema, TState, TShortcuts>;
@@ -168,7 +168,7 @@ export type RegleSchemaCollectionStatus<
   readonly $errors: RegleCollectionErrors<TSchema>;
   /** Collection of all the error messages, collected for all children properties and nested forms.  */
   readonly $silentErrors: RegleCollectionErrors<TSchema>;
-  /** Will return a copy of your state with only the fields that are dirty. By default it will filter out nullish values or objects, but you can override it with the first parameter $extractDirtyFields(false). */
+  /** Will return a copy of your state with only the fields that are dirty. By default, it will filter out nullish values or objects, but you can override it with the first parameter $extractDirtyFields(false). */
   $extractDirtyFields: (filterNullishValues?: boolean) => PartialDeep<TState>;
 } & ([TShortcuts['collections']] extends [never]
     ? {}

--- a/playground/vue3/src/components/TestForm.vue
+++ b/playground/vue3/src/components/TestForm.vue
@@ -6,7 +6,7 @@
     <br />
     <button @click="r$.$validate">validate</button>
 
-    <button @click="isOpen = !isOpen">Assing new value</button>
+    <button @click="isOpen = !isOpen">Assign new value</button>
     <button @click="r$.$reset()">Reset</button>
     <button
       @click="

--- a/playground/vue3/src/components/nested-collection/ParentNested.vue
+++ b/playground/vue3/src/components/nested-collection/ParentNested.vue
@@ -23,9 +23,9 @@
 
     <hr />
     <label>Local Input (not using scoped): </label>
-    <input v-model="independantR$.$value.local" placeholder="Local" />
+    <input v-model="independentR$.$value.local" placeholder="Local" />
     <ul>
-      <li v-for="error of independantR$.$errors.local" :key="error">
+      <li v-for="error of independentR$.$errors.local" :key="error">
         {{ error }}
       </li>
     </ul>
@@ -45,7 +45,7 @@ const { r$ } = useCollectScope('foo');
 
 const show = ref(false);
 
-const { r$: independantR$ } = useRegle(
+const { r$: independentR$ } = useRegle(
   { local: '' },
   {
     local: { minLength: minLength(4) },

--- a/tests/fixtures/validations.fixtures.ts
+++ b/tests/fixtures/validations.fixtures.ts
@@ -149,7 +149,7 @@ export function nestedReactiveWithRefsValidation(): ReturnRegleType {
   );
 }
 
-export function nesteObjectWithRefsValidation(): ReturnRegleType {
+export function nestedObjectWithRefsValidation(): ReturnRegleType {
   const form = {
     level0: ref(0),
     level0Boolean: null as boolean | null,

--- a/tests/unit/createRule/createRule.spec.ts
+++ b/tests/unit/createRule/createRule.spec.ts
@@ -72,7 +72,7 @@ describe('createRule', () => {
     expect(rule.exec('fooo')).toBe(false);
   });
 
-  it('should recognize mutliple parameters with default', async () => {
+  it('should recognize multiple parameters with default', async () => {
     const rule = createRule({
       validator(value, param = false, param2 = true) {
         return true;
@@ -89,7 +89,7 @@ describe('createRule', () => {
     >();
   });
 
-  it('should recognize mutliple parameters with spread', async () => {
+  it('should recognize multiple parameters with spread', async () => {
     const rule = createRule({
       validator(value, ...params: boolean[]) {
         return true;

--- a/tests/unit/scoped-regle/useScopedRegle.spec.ts
+++ b/tests/unit/scoped-regle/useScopedRegle.spec.ts
@@ -293,7 +293,7 @@ describe('useScopedRegle', () => {
     });
   }
 
-  it('should be emtpy', () => {
+  it('should be empty', () => {
     expect(true).toBe(true);
   });
 });

--- a/tests/unit/types-errors/utils.spec-d.ts
+++ b/tests/unit/types-errors/utils.spec-d.ts
@@ -1,7 +1,7 @@
 import type { JoinDiscriminatedUnions } from '@regle/core';
 
 describe('type utils', () => {
-  it('JoinDiscriminatedUnions should bind unions correclty', () => {
+  it('JoinDiscriminatedUnions should bind unions correctly', () => {
     type Union = { name: string } & (
       | { type: 'ONE'; firstName: string }
       | { type: 'TWO'; firstName: number; lastName: string }

--- a/tests/unit/useRegle/async/asyncRules.withObjectRef.spec.ts
+++ b/tests/unit/useRegle/async/asyncRules.withObjectRef.spec.ts
@@ -4,7 +4,7 @@ import { ruleMockIsEvenAsync, ruleMockIsEven, ruleMockIsFooAsync } from '../../.
 import { createRegleComponent } from '../../../utils/test.utils';
 import { nextTick, ref } from 'vue';
 
-function nesteAsyncObjectWithRefsValidation() {
+function nestedAsyncObjectWithRefsValidation() {
   const form = {
     level0Async: ref(0),
     level1: {
@@ -35,7 +35,7 @@ describe('useRegle with async rules and Object refs', async () => {
     vi.useRealTimers();
   });
 
-  const { vm } = createRegleComponent(nesteAsyncObjectWithRefsValidation);
+  const { vm } = createRegleComponent(nestedAsyncObjectWithRefsValidation);
 
   it('should have a initial state', () => {
     expect(vm.r$.$errors).toStrictEqual({

--- a/tests/unit/useRegle/collections/collections.spec.ts
+++ b/tests/unit/useRegle/collections/collections.spec.ts
@@ -181,7 +181,7 @@ describe('collections validations', () => {
     expectTypeOf(vm.r$.$errors.level0.$each[0]?.name).toEqualTypeOf<string[]>();
   });
 
-  it("Array of files should't be considered a collection", async () => {
+  it("Array of files shouldn't be considered a collection", async () => {
     function regleComposable() {
       const form = ref({
         files: [] as File[],

--- a/tests/unit/useRegle/errors/metadata.spec.ts
+++ b/tests/unit/useRegle/errors/metadata.spec.ts
@@ -3,7 +3,7 @@ import { withMessage, withParams, withTooltip } from '@regle/rules';
 import { ref } from 'vue';
 import { createRegleComponent } from '../../../utils/test.utils';
 
-function metadateRules() {
+function metadataRules() {
   const externalDep = ref('external');
 
   const inlineMetadataRule = withTooltip(
@@ -64,7 +64,7 @@ function metadateRules() {
 
 describe('metadata', () => {
   it('correctly return metadata for validator and active handlers', async () => {
-    const { vm } = createRegleComponent(metadateRules);
+    const { vm } = createRegleComponent(metadataRules);
 
     vm.r$.$touch();
     await vm.$nextTick();

--- a/tests/unit/useRegle/global-config/global-rules.spec.ts
+++ b/tests/unit/useRegle/global-config/global-rules.spec.ts
@@ -69,7 +69,7 @@ describe('defineRegleConfig rules', () => {
     expect(vm.r$.$fields.withOr.$errors).toStrictEqual(['Patched rule']);
     expect(vm.r$.$fields.withNot.$errors).toStrictEqual(['Patched rule']);
 
-    // Ensure types are infered well
+    // Ensure types are inferred well
     defineRegleConfig({
       rules: () => ({
         minValue: withMessage(minValue, ({ $params: [min] }) => {

--- a/tests/unit/useRegle/properties/$autoDirty.spec.ts
+++ b/tests/unit/useRegle/properties/$autoDirty.spec.ts
@@ -165,7 +165,7 @@ describe.each([
   });
 
   it('should not re-run validators when a dependency changes`', async () => {
-    function simpleDepencyCase() {
+    function simpleDependencyCase() {
       const form = ref({ password: '', confirm: '' });
 
       return useRegle(
@@ -179,7 +179,7 @@ describe.each([
         }
       );
     }
-    const { vm } = await createRegleComponent(simpleDepencyCase);
+    const { vm } = await createRegleComponent(simpleDependencyCase);
 
     shouldBePristineField(vm.r$.$fields.password);
     shouldBePristineField(vm.r$.$fields.confirm);

--- a/tests/unit/useRegle/properties/$correct.spec.ts
+++ b/tests/unit/useRegle/properties/$correct.spec.ts
@@ -27,7 +27,7 @@ function regleFixture() {
 }
 
 describe('$correct validation property', () => {
-  it('should compyted the $correct property correctly', async () => {
+  it('should computed the $correct property correctly', async () => {
     const { vm } = createRegleComponent(regleFixture);
 
     expect(vm.r$.$fields.nested.$correct).toBe(false);

--- a/tests/unit/useRegle/properties/$pending.spec.ts
+++ b/tests/unit/useRegle/properties/$pending.spec.ts
@@ -5,7 +5,7 @@ import { createRegleComponent } from '../../../utils/test.utils';
 import { nextTick, ref } from 'vue';
 import { shouldBeErrorField, shouldBePristineField, shouldBeValidField } from '../../../utils/validations.utils';
 
-function nesteAsyncObjectWithRefsValidation() {
+function nestedAsyncObjectWithRefsValidation() {
   const form = ref({
     level0: 0,
     level1: {
@@ -41,7 +41,7 @@ describe('$pending', () => {
   });
 
   it('sets `$pending` to `true`, when async validators are used and are being resolved', async () => {
-    const { vm } = await createRegleComponent(nesteAsyncObjectWithRefsValidation);
+    const { vm } = await createRegleComponent(nestedAsyncObjectWithRefsValidation);
     await nextTick();
 
     shouldBePristineField(vm.r$, true);
@@ -91,7 +91,7 @@ describe('$pending', () => {
   });
 
   it('propagates `$pending` up to the top most parent', async () => {
-    const { vm } = await createRegleComponent(nesteAsyncObjectWithRefsValidation);
+    const { vm } = await createRegleComponent(nestedAsyncObjectWithRefsValidation);
 
     vm.r$.$value.level1.child = 1;
     await vi.advanceTimersByTimeAsync(200);
@@ -109,7 +109,7 @@ describe('$pending', () => {
   });
 
   it('propagates should make a boolean shift when editing a async rule', async () => {
-    const { vm } = await createRegleComponent(nesteAsyncObjectWithRefsValidation);
+    const { vm } = await createRegleComponent(nestedAsyncObjectWithRefsValidation);
 
     expect(vm.r$.$correct).toBe(true);
 
@@ -132,7 +132,7 @@ describe('$pending', () => {
   });
 
   it('propagates `$pending` from a collection child', async () => {
-    const { vm } = await createRegleComponent(nesteAsyncObjectWithRefsValidation);
+    const { vm } = await createRegleComponent(nestedAsyncObjectWithRefsValidation);
 
     vm.r$.$value.collection[0].child = 1;
     await vi.advanceTimersByTimeAsync(200);

--- a/tests/unit/useRegle/properties/$rewardEarly.spec.ts
+++ b/tests/unit/useRegle/properties/$rewardEarly.spec.ts
@@ -111,7 +111,7 @@ describe('$rewardEarly', () => {
       shouldBeErrorField(vm.r$.$fields.level1.$fields.collection.$each[0].$fields.name);
     });
 
-    function nesteAsyncObjectWithRefsValidation() {
+    function nestedAsyncObjectWithRefsValidation() {
       const form = ref({
         level0: 0,
         level1: {
@@ -140,7 +140,7 @@ describe('$rewardEarly', () => {
     describe('async', () => {
       it('sets state as normal, stops validating upon success', async () => {
         vi.useFakeTimers();
-        const { vm } = createRegleComponent(nesteAsyncObjectWithRefsValidation);
+        const { vm } = createRegleComponent(nestedAsyncObjectWithRefsValidation);
         expect(mockedValidations.isEven).toHaveBeenCalledTimes(0);
         vm.r$.$fields.level0.$validate();
         await vi.advanceTimersByTimeAsync(1200);

--- a/tests/unit/useRegle/properties/$touch.spec.ts
+++ b/tests/unit/useRegle/properties/$touch.spec.ts
@@ -46,7 +46,7 @@ describe('.$touch', () => {
     expect(vm.r$.$fields.user.$fields.lastName.$dirty).toBe(true);
   });
 
-  it('should not update the `$dirty` state on the property it wasnt used on', async () => {
+  it("should not update the `$dirty` state on the property it wasn't used on", async () => {
     const { vm } = await createRegleComponent(simpleNestedStateWithMixedValidation);
 
     expect(vm.r$.$fields.email.$invalid).toBe(true);

--- a/tests/unit/useRegle/stories/base-story.all-state-types.spec.ts
+++ b/tests/unit/useRegle/stories/base-story.all-state-types.spec.ts
@@ -4,7 +4,7 @@ import {
   nestedReactiveWithRefsValidation,
   nestedRefObjectValidation,
   nestedRefObjectValidationComputed,
-  nesteObjectWithRefsValidation,
+  nestedObjectWithRefsValidation,
 } from '../../../fixtures';
 import { createRegleComponent } from '../../../utils/test.utils';
 import {
@@ -19,7 +19,7 @@ describe.each([
   ['ref', nestedRefObjectValidation],
   ['ref state with computed rules', nestedRefObjectValidationComputed],
   ['reactive with ref', nestedReactiveWithRefsValidation],
-  ['object with refs state', nesteObjectWithRefsValidation],
+  ['object with refs state', nestedObjectWithRefsValidation],
 ])('useRegle with %s', async (title, regle) => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/tests/unit/useRegle/stories/single-field.spec.ts
+++ b/tests/unit/useRegle/stories/single-field.spec.ts
@@ -4,14 +4,14 @@ import { ref } from 'vue';
 import { createRegleComponent } from '../../../utils/test.utils';
 import { shouldBeErrorField, shouldBeInvalidField, shouldBeValidField } from '../../../utils/validations.utils';
 
-function singleFieldValidion() {
+function singleFieldValidation() {
   const formState = ref<number | undefined>();
   return useRegle(formState, { required, numeric });
 }
 
 describe('useRegle should work with single field validation', () => {
   it('should behave like a object state', async () => {
-    const { vm } = createRegleComponent(singleFieldValidion);
+    const { vm } = createRegleComponent(singleFieldValidation);
 
     shouldBeInvalidField(vm.r$);
 
@@ -36,7 +36,7 @@ describe('useRegle should work with single field validation', () => {
   });
 
   it('should have the correct type when using $validate', async () => {
-    const { vm } = createRegleComponent(singleFieldValidion);
+    const { vm } = createRegleComponent(singleFieldValidation);
 
     const { data, valid } = await vm.r$.$validate();
 

--- a/ui-tests/fixtures/ui-vue3/src/components/regle.global.config.ts
+++ b/ui-tests/fixtures/ui-vue3/src/components/regle.global.config.ts
@@ -6,7 +6,7 @@ import { passwordStrength, type DiversityType, type Options } from 'check-passwo
 
 const diversityTypes: DiversityType[] = ['lowercase', 'uppercase', 'symbol', 'number'];
 const diversityMessages: Record<DiversityType, string> = {
-  lowercase: 'At least one owercase letter (a-z)',
+  lowercase: 'At least one lowercase letter (a-z)',
   uppercase: 'At least one uppercase letter (A-Z)',
   number: 'At least one number (0-9)',
   symbol: 'At least one symbol ($€@&..)',

--- a/ui-tests/specs/base.uispec.ts
+++ b/ui-tests/specs/base.uispec.ts
@@ -39,7 +39,7 @@ test('it should render the page correctly', async ({ index }) => {
   expect(await index.page.$('[data-testid=project-0-url] .errors')).toBeNull();
 
   await expect(index.page.locator('[data-testid=password] .tooltips')).toContainText(
-    `At least one owercase letter (a-z)At least one uppercase letter (A-Z)At least one symbol ($€@&..)At least one number (0-9)At least 8 characters`
+    `At least one lowercase letter (a-z)At least one uppercase letter (A-Z)At least one symbol ($€@&..)At least one number (0-9)At least 8 characters`
   );
   await expect(index.page.locator('[data-testid=confirmPassword] .errors')).toContainText(
     'You need to provide a value'


### PR DESCRIPTION
Fixes for various spelling errors I was able to find throughout the project.

Commit 809b93a2c80f8ee3d40c251780438d06af4281a2 contains a BC break so I have separated it in it's own commit in case you don't wish to merge it. I could also remove it from this PR and submit it separately if you would prefer.