### PR TITLE
feat: implement Standard Schema spec

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -85,6 +85,7 @@ const AdvancedUsage: (DefaultTheme.NavItemWithLink | DefaultTheme.NavItemChildre
   { text: 'Rules metadata', link: '/advanced-usage/rule-metadata' },
   { text: 'Async validators', link: '/advanced-usage/async-validation' },
   { text: 'Global configuration', link: '/advanced-usage/global-config' },
+  { text: 'Standard Schema', link: '/advanced-usage/standard-schema' },
   { text: 'Server errors', link: '/advanced-usage/external-errors' },
   { text: 'Variants', link: '/advanced-usage/variants' },
   { text: 'Scoped validation', link: '/advanced-usage/scoped-validation' },
@@ -101,10 +102,6 @@ const Typescript: (DefaultTheme.NavItemWithLink | DefaultTheme.NavItemChildren)[
   {
     text: 'Rules definitions',
     link: '/typescript/typing-rules',
-  },
-  {
-    text: 'Infer state from rules',
-    link: '/typescript/infer-state-from-rules',
   },
 ];
 

--- a/docs/src/advanced-usage/standard-schema.md
+++ b/docs/src/advanced-usage/standard-schema.md
@@ -1,17 +1,76 @@
 ---
-title: Infer state from rules
-description: Write your validations in the Zod way
+title: Standard Schema
+description: Use Regle as a Standard Schema library
 ---
 
-# Infer state from rules
+# Standard Schema
 
-Regle is state first, that means that you write your rules depending on the state structure, that's the model based way that Vuelidate introduced.
+Regle implements the [Standard Schema](https://standardschema.dev/) specification.
 
-With Schema libraries like Zod or Valibot, it's the opposite: the state type depends on the schema output.
+This means that you can use Regle on any third party package that supports the Standard Schema spec.
 
-This mental model may differ to some people, the good news is Regle support both ways.
+Regle can also use itself as a schema library when using `useRegleSchema`.
 
-## `InferInput`
+## Usage
+
+```ts
+import { useRegle } from '@regle/core';
+import { required } from '@regle/rules';
+
+const { r$ } = useRegle({ name: '' }, {
+  name: { required }
+})
+
+const result = await r$.['~standard'].validate({ name: '' });
+
+console.log(result.issues);
+```
+
+# `useRules`
+
+`useRules` is a composable that allows you to write your rules like a schema library, without declaring a state.
+
+Under the hood, it still uses the `useRegle` composable, but it doesn't accept a state parameter, it will create a empty state from the rules.
+
+
+## Schema only usage
+
+```ts
+import { useRules } from '@regle/core';
+import { required, string } from '@regle/rules';
+
+const schema = useRules({
+  name: { string, required }
+})
+
+const result = await schema['~standard'].validate({ name: '' });
+```
+
+## Composition usage
+
+```vue
+<template>
+  <input 
+     v-model='r$.$value.email' 
+    :class="{ error: r$.email.$error }" 
+    placeholder='Type your email'
+  />
+
+  <li v-for="error of r$.email.$errors" :key='error'>
+    {{ error }}
+  </li>
+</template>
+<script setup lang="ts">
+import { useRules } from '@regle/core';
+import { required, string } from '@regle/rules';
+
+const r$ = useRules({
+  name: { string, required }
+})
+</script>
+```
+
+# `InferInput`
 
 `InferInput` is an utility type that can produce a object state from any rules object.
 

--- a/docs/src/blog/regle-1.2.md
+++ b/docs/src/blog/regle-1.2.md
@@ -91,7 +91,7 @@ type State = InferInput<typeof rules>;
 
 
 :::info
-You can check the [full docs here](/typescript/infer-state-from-rules)
+You can check the [full docs here](/advanced-usage/standard-schema)
 :::
 
 

--- a/docs/src/core-concepts/index.md
+++ b/docs/src/core-concepts/index.md
@@ -158,7 +158,7 @@ import {
 Check out the [complete list of built-in rules](/core-concepts/rules/built-in-rules) to see everything available.
 
 :::tip Type-First Validation
-If you prefer to define your validation schema first (like with Zod) and infer your TypeScript types from it, check out [how to infer state from rules](/typescript/infer-state-from-rules).
+If you prefer to define your validation schema first (like with Zod) and infer your TypeScript types from it, check out [Standard Schema usage](/advanced-usage/standard-schema).
 :::
 
 ## The stored result : `r$`

--- a/docs/src/core-concepts/validation-properties.md
+++ b/docs/src/core-concepts/validation-properties.md
@@ -131,10 +131,14 @@ Return the current key name of the field.
 
 
 ### `$validate` 
-- Type: `() => Promise<false | SafeOutput<TState>>`
+- Type: `(forceValues?: TState) => Promise<false | SafeOutput<TState>>`
 
 Sets all properties as dirty, triggering all rules. 
 It returns a promise that will either resolve to `false` or a Headless copy of your form state. Values that had the `required` rule will be transformed into a non-nullable value (type only).
+
+### `forceValues` parameter
+
+The first argument is optional and can be used to assign a new state before validating. It's equivalent to use `r$.$value = x` and `r$.$validate();`.
 
 ### `$extractDirtyFields` 
 - Type: `(filterNullishValues = true) => PartialDeep<TState>`

--- a/docs/src/typescript/infer-state-from-rules.md
+++ b/docs/src/typescript/infer-state-from-rules.md
@@ -45,6 +45,22 @@ type State = InferInput<typeof rules>;
 <br/>
 <br/>
 
+## `useRules`
+
+`useRules` is a composable that allows you to write your rules in a more declarative way.
+
+It works exactly like `useRegle`, but it doesn't accept a state parameter, it will create a emp from the rules.
+
+```ts twoslash
+
+import { useRules, type InferInput } from '@regle/core';
+import { required, string } from '@regle/rules';
+
+const rules = useRules({
+  name: { required, string },
+});
+```
+
 ## `refineRules`
 
 Regle is state first because in real world forms, rules can depend a state values.   

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,9 @@
       "optional": true
     }
   },
+  "dependencies": {
+    "@standard-schema/spec": "1.0.0"
+  },
   "devDependencies": {
     "@total-typescript/ts-reset": "catalog:",
     "@types/node": "catalog:",

--- a/packages/core/src/core/defineRegleConfig.ts
+++ b/packages/core/src/core/defineRegleConfig.ts
@@ -1,6 +1,6 @@
 import type { Merge } from 'type-fest';
 import type { AllRulesDeclarations, RegleBehaviourOptions, RegleShortcutDefinition } from '../types';
-import { createUseRegleComposable, type useRegleFn } from './useRegle';
+import { createUseRegleComposable, createUseRulesComposable, type useRegleFn, type useRulesFn } from './useRegle';
 import { createInferRuleHelper, type inferRulesFn } from './useRegle/inferRules';
 import { merge } from '../../../shared';
 
@@ -30,13 +30,16 @@ export function defineRegleConfig<
 }): {
   useRegle: useRegleFn<TCustomRules, TShortcuts>;
   inferRules: inferRulesFn<TCustomRules>;
+  useRules: useRulesFn<TCustomRules, TShortcuts>;
 } {
   const useRegle = createUseRegleComposable<TCustomRules, TShortcuts>(rules, modifiers, shortcuts as any);
+  const useRules = createUseRulesComposable<TCustomRules, TShortcuts>(rules, modifiers, shortcuts as any);
   useRegle.__config = { rules, modifiers, shortcuts };
+  useRules.__config = { rules, modifiers, shortcuts };
 
   const inferRules = createInferRuleHelper<TCustomRules>();
 
-  return { useRegle, inferRules };
+  return { useRegle, inferRules, useRules };
 }
 
 /**

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -13,3 +13,4 @@ export {
 } from './createScopedUseRegle';
 export { createVariant, narrowVariant, variantToRef } from './createVariant';
 export { defineRules, refineRules } from './refineRules';
+export { useRules, type useRulesFn } from './useRegle/useRules';

--- a/packages/core/src/core/mergeRegles.ts
+++ b/packages/core/src/core/mergeRegles.ts
@@ -1,4 +1,4 @@
-import type { PartialDeep } from 'type-fest';
+import type { EmptyObject, PartialDeep } from 'type-fest';
 import type {
   PromiseReturn,
   RegleCommonStatus,
@@ -34,10 +34,16 @@ export type MergedRegles<
   readonly $silentErrors: {
     [K in keyof TRegles]: TRegles[K]['$silentErrors'];
   };
+  readonly $issues: {
+    [K in keyof TRegles]: TRegles[K]['$issues'];
+  };
+  readonly $silentIssues: {
+    [K in keyof TRegles]: TRegles[K]['$silentIssues'];
+  };
   /** Will return a copy of your state with only the fields that are dirty. By default it will filter out nullish values or objects, but you can override it with the first parameter $extractDirtyFields(false). */
   $extractDirtyFields: (filterNullishValues?: boolean) => PartialDeep<TValue>;
   /** Sets all properties as dirty, triggering all rules. It returns a promise that will either resolve to false or a type safe copy of your form state. Values that had the required rule will be transformed into a non-nullable value (type only). */
-  $validate: () => Promise<MergedReglesResult<TRegles>>;
+  $validate: (forceValues?: TRegles['$value']) => Promise<MergedReglesResult<TRegles>>;
 };
 
 export type MergedScopedRegles<TValue extends Record<string, unknown>[] = Record<string, unknown>[]> = Omit<
@@ -52,8 +58,17 @@ export type MergedScopedRegles<TValue extends Record<string, unknown>[] = Record
   readonly $errors: RegleValidationErrors<Record<string, unknown>>[];
   /** Collection of all registered Regles instances silent errors */
   readonly $silentErrors: RegleValidationErrors<Record<string, unknown>>[];
+  /** Collection of all registered Regles instances issues */
+  readonly $issues: RegleValidationErrors<Record<string, unknown>, false, true>[];
+  /** Collection of all registered Regles instances silent issues */
+  readonly $silentIssues: RegleValidationErrors<Record<string, unknown>, false, true>[];
   /** Sets all properties as dirty, triggering all rules. It returns a promise that will either resolve to false or a type safe copy of your form state. Values that had the required rule will be transformed into a non-nullable value (type only). */
-  $validate: () => Promise<{ valid: boolean; data: TValue }>;
+  $validate: (forceValues?: TValue) => Promise<{
+    valid: boolean;
+    data: TValue;
+    errors: RegleValidationErrors<Record<string, unknown>>[];
+    issues: RegleValidationErrors<Record<string, unknown>>[];
+  }>;
 };
 
 type MergedReglesResult<TRegles extends Record<string, SuperCompatibleRegleRoot>> =
@@ -62,12 +77,20 @@ type MergedReglesResult<TRegles extends Record<string, SuperCompatibleRegleRoot>
       data: {
         [K in keyof TRegles]: Extract<PromiseReturn<ReturnType<TRegles[K]['$validate']>>, { valid: false }>['data'];
       };
+      errors: {
+        [K in keyof TRegles]: TRegles[K]['$errors'];
+      };
+      issues: {
+        [K in keyof TRegles]: TRegles[K]['$issues'];
+      };
     }
   | {
       valid: true;
       data: {
         [K in keyof TRegles]: Extract<PromiseReturn<ReturnType<TRegles[K]['$validate']>>, { valid: true }>['data'];
       };
+      errors: EmptyObject;
+      issues: EmptyObject;
     };
 
 export function mergeRegles<TRegles extends Record<string, SuperCompatibleRegleRoot>, TScoped extends boolean = false>(
@@ -158,6 +181,34 @@ export function mergeRegles<TRegles extends Record<string, SuperCompatibleRegleR
     });
   });
 
+  const $issues = computed(() => {
+    if (scoped) {
+      return Object.entries(regles).map(([_, regle]) => {
+        return regle.$issues;
+      });
+    } else {
+      return Object.fromEntries(
+        Object.entries(regles).map(([key, regle]) => {
+          return [key, regle.$issues];
+        })
+      );
+    }
+  });
+
+  const $silentIssues = computed(() => {
+    if (scoped) {
+      return Object.entries(regles).map(([_, regle]) => {
+        return regle.$silentIssues;
+      });
+    } else {
+      return Object.fromEntries(
+        Object.entries(regles).map(([key, regle]) => {
+          return [key, regle.$silentIssues];
+        })
+      );
+    }
+  });
+
   const $errors = computed(() => {
     if (scoped) {
       return Object.entries(regles).map(([_, regle]) => {
@@ -233,8 +284,11 @@ export function mergeRegles<TRegles extends Record<string, SuperCompatibleRegleR
     });
   }
 
-  async function $validate(): Promise<RegleResult<any, any>> {
+  async function $validate(forceValues?: any): Promise<RegleResult<any, any> & { errors: any; issues: any }> {
     try {
+      if (forceValues) {
+        $value.value = forceValues;
+      }
       const data = $value.value;
 
       const results = await Promise.allSettled(
@@ -250,9 +304,9 @@ export function mergeRegles<TRegles extends Record<string, SuperCompatibleRegleR
           return false;
         }
       });
-      return { valid: validationResults, data };
+      return { valid: validationResults, data, errors: $errors.value, issues: $issues.value };
     } catch {
-      return { valid: false, data: $value.value };
+      return { valid: false, data: $value.value, errors: $errors.value, issues: $issues.value };
     }
   }
 
@@ -261,7 +315,9 @@ export function mergeRegles<TRegles extends Record<string, SuperCompatibleRegleR
       $silentValue: $silentValue as any,
     }),
     $errors,
-    $silentErrors: $silentErrors,
+    $issues,
+    $silentIssues,
+    $silentErrors,
     $instances,
     $value: $value as any,
     $dirty,

--- a/packages/core/src/core/useRegle/index.ts
+++ b/packages/core/src/core/useRegle/index.ts
@@ -2,3 +2,4 @@ export * from './useRegle';
 export { inferRules, type inferRulesFn } from './inferRules';
 export { useRootStorage } from './root';
 export { flatErrors } from './useErrors';
+export * from './useRules';

--- a/packages/core/src/core/useRegle/root/standard-schemas.ts
+++ b/packages/core/src/core/useRegle/root/standard-schemas.ts
@@ -1,0 +1,18 @@
+import type { $InternalRegleResult, RegleStandardSchema } from '../../../types';
+import { flatErrors } from '../useErrors';
+
+export function createStandardSchema(validateFn: (value: any) => Promise<$InternalRegleResult>): RegleStandardSchema {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'regle',
+      validate: async (value: any) => {
+        const { valid, data, errors } = await validateFn(value);
+        if (valid) {
+          return { value: data, issues: [] };
+        }
+        return { issues: flatErrors(errors, { includePath: true }) };
+      },
+    } as const,
+  };
+}

--- a/packages/core/src/core/useRegle/root/standard-schemas.ts
+++ b/packages/core/src/core/useRegle/root/standard-schemas.ts
@@ -1,7 +1,8 @@
-import type { $InternalRegleResult, RegleStandardSchema } from '../../../types';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { $InternalRegleResult } from '../../../types';
 import { flatErrors } from '../useErrors';
 
-export function createStandardSchema(validateFn: (value: any) => Promise<$InternalRegleResult>): RegleStandardSchema {
+export function createStandardSchema(validateFn: (value: any) => Promise<$InternalRegleResult>): StandardSchemaV1 {
   return {
     '~standard': {
       version: 1,

--- a/packages/core/src/core/useRegle/shared.rootRegle.ts
+++ b/packages/core/src/core/useRegle/shared.rootRegle.ts
@@ -1,0 +1,65 @@
+import type { Ref } from 'vue';
+import { computed, isRef, ref, shallowRef, triggerRef, watchEffect, type ComputedRef } from 'vue';
+import type { DeepMaybeRef, LocalRegleBehaviourOptions, RegleBehaviourOptions } from '../..';
+import { cloneDeep, isObject } from '../../../../shared';
+import type {
+  $InternalReglePartialRuleTree,
+  AllRulesDeclarations,
+  RegleShortcutDefinition,
+  ResolvedRegleBehaviourOptions,
+} from '../../types';
+import type { PrimitiveTypes } from '../../types/utils';
+import { useRootStorage } from './root';
+
+interface RootRegleOptions {
+  state: Ref<Record<string, any> | PrimitiveTypes>;
+  rulesFactory?: Record<string, any> | ((...args: any[]) => Record<string, any>) | ComputedRef<Record<string, any>>;
+  options?: Partial<DeepMaybeRef<RegleBehaviourOptions>> &
+    LocalRegleBehaviourOptions<Record<string, any>, Record<string, any>, any>;
+  globalOptions: RegleBehaviourOptions;
+  customRules?: () => Partial<AllRulesDeclarations>;
+  shortcuts?: RegleShortcutDefinition | undefined;
+}
+
+export function createRootRegleLogic({
+  state,
+  rulesFactory,
+  options,
+  globalOptions,
+  customRules,
+  shortcuts,
+}: RootRegleOptions) {
+  const definedRules = isRef(rulesFactory)
+    ? rulesFactory
+    : typeof rulesFactory === 'function'
+      ? undefined
+      : computed(() => rulesFactory);
+
+  const resolvedOptions: ResolvedRegleBehaviourOptions = {
+    ...globalOptions,
+    ...options,
+  } as any;
+
+  const watchableRulesGetters = shallowRef<Record<string, any> | null>(definedRules ?? {});
+
+  if (typeof rulesFactory === 'function') {
+    watchEffect(() => {
+      watchableRulesGetters.value = rulesFactory(state);
+      triggerRef(watchableRulesGetters);
+    });
+  }
+
+  const initialState = ref(isObject(state.value) ? { ...cloneDeep(state.value) } : cloneDeep(state.value));
+
+  const originalState = isObject(state.value) ? { ...cloneDeep(state.value) } : cloneDeep(state.value);
+
+  return useRootStorage({
+    scopeRules: watchableRulesGetters as ComputedRef<$InternalReglePartialRuleTree>,
+    state: state,
+    options: resolvedOptions,
+    initialState,
+    originalState,
+    customRules,
+    shortcuts,
+  });
+}

--- a/packages/core/src/core/useRegle/useErrors.ts
+++ b/packages/core/src/core/useRegle/useErrors.ts
@@ -128,7 +128,7 @@ export function flatErrors(
 function iterateErrors(
   errors: $InternalRegleErrors,
   includePath = false,
-  _path?: string[]
+  _path?: PropertyKey[]
 ): (string | StandardSchemaV1.Issue)[] {
   const path = includePath && !_path ? [] : _path;
   if (Array.isArray(errors) && errors.every((err) => !isObject(err))) {
@@ -142,8 +142,7 @@ function iterateErrors(
     const selfErrors = path?.length
       ? (errors.$self?.map((err) => ({ message: err, path: path ?? [] }) as StandardSchemaV1.Issue) ?? [])
       : (errors.$self ?? []);
-    const eachErrors =
-      errors.$each?.map((err, index) => iterateErrors(err, includePath, path?.concat(index.toString()))) ?? [];
+    const eachErrors = errors.$each?.map((err, index) => iterateErrors(err, includePath, path?.concat(index))) ?? [];
     return selfErrors?.concat(eachErrors.flat());
   } else {
     // Nested errors

--- a/packages/core/src/core/useRegle/useRegle.ts
+++ b/packages/core/src/core/useRegle/useRegle.ts
@@ -1,8 +1,6 @@
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref } from 'vue';
-import { computed, isRef, ref, shallowRef, triggerRef, watchEffect } from 'vue';
-import { cloneDeep, isObject } from '../../../../shared';
+import { isRef, ref } from 'vue';
 import type {
-  $InternalReglePartialRuleTree,
   AllRulesDeclarations,
   CustomRulesDeclarationTree,
   DeepReactiveState,
@@ -14,7 +12,6 @@ import type {
   RegleShortcutDefinition,
   RegleSingleField,
   RegleValidationGroupEntry,
-  ResolvedRegleBehaviourOptions,
 } from '../../types';
 import type {
   DeepExact,
@@ -26,7 +23,6 @@ import type {
   PrimitiveTypes,
   Unwrap,
 } from '../../types/utils';
-import { useRootStorage } from './root';
 import { createRootRegleLogic } from './shared.rootRegle';
 
 export type useRegleFnOptions<

--- a/packages/core/src/core/useRegle/useRules.ts
+++ b/packages/core/src/core/useRegle/useRules.ts
@@ -1,10 +1,8 @@
-import type { ComputedRef, MaybeRef, Raw } from 'vue';
-import { computed, isRef, ref, shallowRef, triggerRef, watchEffect } from 'vue';
-import { cloneDeep, isEmpty, isObject } from '../../../../shared';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { ComputedRef, MaybeRef, Raw } from 'vue';
+import { computed, isRef, ref } from 'vue';
+import { isEmpty, isObject } from '../../../../shared';
 import type {
-  $InternalReglePartialRuleTree,
-  $InternalRegleStatusType,
   AllRulesDeclarations,
   CustomRulesDeclarationTree,
   LocalRegleBehaviourOptions,
@@ -15,11 +13,9 @@ import type {
   RegleShortcutDefinition,
   RegleUnknownRulesTree,
   RegleValidationGroupEntry,
-  ResolvedRegleBehaviourOptions,
 } from '../../types';
 import type { DeepMaybeRef, InferInput, JoinDiscriminatedUnions, PrimitiveTypes, Unwrap } from '../../types/utils';
 import { isRuleDef } from './guards';
-import { useRootStorage } from './root';
 import { createRootRegleLogic } from './shared.rootRegle';
 
 function createEmptyRuleState(rules: RegleUnknownRulesTree | RegleRuleDecl): Record<string, any> | any {

--- a/packages/core/src/core/useRegle/useRules.ts
+++ b/packages/core/src/core/useRegle/useRules.ts
@@ -1,0 +1,178 @@
+import type { ComputedRef, MaybeRef, Raw } from 'vue';
+import { computed, isRef, ref, shallowRef, triggerRef, watchEffect } from 'vue';
+import { cloneDeep, isEmpty, isObject } from '../../../../shared';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type {
+  $InternalReglePartialRuleTree,
+  $InternalRegleStatusType,
+  AllRulesDeclarations,
+  CustomRulesDeclarationTree,
+  LocalRegleBehaviourOptions,
+  RegleBehaviourOptions,
+  RegleFieldStatus,
+  RegleRoot,
+  RegleRuleDecl,
+  RegleShortcutDefinition,
+  RegleUnknownRulesTree,
+  RegleValidationGroupEntry,
+  ResolvedRegleBehaviourOptions,
+} from '../../types';
+import type { DeepMaybeRef, InferInput, JoinDiscriminatedUnions, PrimitiveTypes, Unwrap } from '../../types/utils';
+import { isRuleDef } from './guards';
+import { useRootStorage } from './root';
+import { flatErrors } from './useErrors';
+
+function createEmptyRuleState(rules: RegleUnknownRulesTree | RegleRuleDecl): Record<string, any> | any {
+  const result: Record<string, any> = {};
+
+  if (Object.entries(rules).some(([_, rule]) => isRuleDef(rule) || typeof rule === 'function')) {
+    return null;
+  }
+
+  for (const key in rules) {
+    const item = rules[key];
+
+    if (!!item && isObject(item) && '$each' in item && item['$each'] && isObject(item['$each'])) {
+      result[key] = [createEmptyRuleState(item['$each'] as any)];
+    } else if (
+      isObject(item) &&
+      !isEmpty(item) &&
+      !Object.entries(item).some(([_, rule]) => isRuleDef(rule) || typeof rule === 'function')
+    ) {
+      result[key] = createEmptyRuleState(item as any);
+    } else {
+      result[key] = null;
+    }
+  }
+
+  return result;
+}
+
+export type useRulesFnOptions<
+  TRules extends RegleUnknownRulesTree | RegleRuleDecl,
+  TValidationGroups extends Record<string, RegleValidationGroupEntry[]>,
+  TState = InferInput<TRules>,
+> = Partial<DeepMaybeRef<RegleBehaviourOptions>> &
+  LocalRegleBehaviourOptions<
+    JoinDiscriminatedUnions<TState extends Record<string, any> ? Unwrap<TState> : {}>,
+    TState extends Record<string, any> ? (TRules extends Record<string, any> ? TRules : {}) : {},
+    TValidationGroups
+  >;
+
+export interface useRulesFn<
+  TCustomRules extends Partial<AllRulesDeclarations>,
+  TShortcuts extends RegleShortcutDefinition<any> = never,
+> {
+  <
+    TRules extends RegleUnknownRulesTree | RegleRuleDecl,
+    TDecl extends RegleRuleDecl<NonNullable<TState>, Partial<AllRulesDeclarations> & TCustomRules>,
+    TValidationGroups extends Record<string, RegleValidationGroupEntry[]>,
+    TState extends Record<string, any> = InferInput<TRules>,
+  >(
+    rulesFactory: TState extends Record<string, any> ? MaybeRef<TRules> | ((...args: any[]) => TRules) : {},
+    options?: useRulesFnOptions<TRules, TValidationGroups, TState>
+  ): NonNullable<TState> extends PrimitiveTypes
+    ? Raw<RegleFieldStatus<NonNullable<TState>, TDecl, TShortcuts>> & StandardSchemaV1<TState>
+    : Raw<
+        RegleRoot<
+          TState extends Record<string, any> ? Unwrap<TState> : {},
+          TRules extends Record<string, any> ? TRules : {},
+          TValidationGroups,
+          TShortcuts
+        >
+      > &
+        StandardSchemaV1<TState>;
+  __config?: {
+    rules?: () => CustomRulesDeclarationTree;
+    modifiers?: RegleBehaviourOptions;
+    shortcuts?: TShortcuts;
+  };
+}
+
+export function createUseRulesComposable<
+  TCustomRules extends Partial<AllRulesDeclarations>,
+  TShortcuts extends RegleShortcutDefinition<any>,
+>(
+  customRules?: () => TCustomRules,
+  options?: RegleBehaviourOptions,
+  shortcuts?: RegleShortcutDefinition | undefined
+): useRulesFn<TCustomRules, TShortcuts> {
+  const globalOptions: RegleBehaviourOptions = {
+    autoDirty: options?.autoDirty,
+    lazy: options?.lazy,
+    rewardEarly: options?.rewardEarly,
+    silent: options?.silent,
+    clearExternalErrorsOnChange: options?.clearExternalErrorsOnChange,
+  };
+
+  function useRules(
+    rulesFactory: Record<string, any> | ((...args: any[]) => Record<string, any>) | ComputedRef<Record<string, any>>,
+    options?: Partial<DeepMaybeRef<RegleBehaviourOptions>> &
+      LocalRegleBehaviourOptions<Record<string, any>, Record<string, any>, any>
+  ): RegleRoot<Record<string, any>, Record<string, any>, any, any> & StandardSchemaV1<any> {
+    const definedRules = isRef(rulesFactory)
+      ? rulesFactory
+      : typeof rulesFactory === 'function'
+        ? undefined
+        : computed(() => rulesFactory);
+
+    const resolvedOptions: ResolvedRegleBehaviourOptions = {
+      ...globalOptions,
+      ...options,
+    } as any;
+
+    const processedState = ref(createEmptyRuleState(definedRules?.value as any));
+
+    const watchableRulesGetters = shallowRef<Record<string, any> | null>(definedRules ?? {});
+
+    if (typeof rulesFactory === 'function') {
+      watchEffect(() => {
+        watchableRulesGetters.value = rulesFactory(processedState);
+        triggerRef(watchableRulesGetters);
+      });
+    }
+
+    const initialState = ref(
+      isObject(processedState.value) ? { ...cloneDeep(processedState.value) } : cloneDeep(processedState.value)
+    );
+
+    const originalState = isObject(processedState.value)
+      ? { ...cloneDeep(processedState.value) }
+      : cloneDeep(processedState.value);
+
+    const regle: {
+      regle: ($InternalRegleStatusType & StandardSchemaV1<any>) | undefined;
+    } = useRootStorage({
+      scopeRules: watchableRulesGetters as ComputedRef<$InternalReglePartialRuleTree>,
+      state: processedState,
+      options: resolvedOptions,
+      initialState,
+      originalState,
+      customRules,
+      shortcuts,
+    }) as any;
+
+    return regle.regle as any;
+  }
+
+  return useRules as any;
+}
+
+/**
+ * useRules is a clone of useRegle, without the need to provide a state.
+ *
+ * It accepts the following inputs:
+ *
+ * @param rules - Your rules object
+ * @param modifiers - Customize regle behaviour
+ * 
+ * ```ts
+ * import { useRules } from '@regle/core';
+   import { required } from '@regle/rules';
+
+   const { r$ } = useRules({
+     email: { required }
+   })
+ * ```
+ */
+export const useRules = createUseRulesComposable();

--- a/packages/core/src/core/useRegle/useRules.ts
+++ b/packages/core/src/core/useRegle/useRules.ts
@@ -20,7 +20,6 @@ import type {
 import type { DeepMaybeRef, InferInput, JoinDiscriminatedUnions, PrimitiveTypes, Unwrap } from '../../types/utils';
 import { isRuleDef } from './guards';
 import { useRootStorage } from './root';
-import { flatErrors } from './useErrors';
 
 function createEmptyRuleState(rules: RegleUnknownRulesTree | RegleRuleDecl): Record<string, any> | any {
   const result: Record<string, any> = {};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   useRootStorage,
   useScopedRegle,
   variantToRef,
+  useRules,
   type CommonAlphaOptions,
   type CommonComparisonOptions,
   type CreateScopedUseRegleOptions,
@@ -24,6 +25,7 @@ export {
   type MergedScopedRegles,
   type useCollectScopeFn,
   type useRegleFn,
+  type useRulesFn,
   type UseScopedRegleOptions,
 } from './core';
 export { InternalRuleType } from './types';

--- a/packages/core/src/types/core/modifiers.types.ts
+++ b/packages/core/src/types/core/modifiers.types.ts
@@ -94,7 +94,7 @@ export type ResolvedRegleBehaviourOptions = DeepMaybeRef<RequiredDeep<RegleBehav
   LocalRegleBehaviourOptions<Record<string, any>, Record<string, any>, Record<string, any[]>>;
 
 export type ShortcutCommonFn<T extends Record<string, any>> = {
-  [x: string]: (element: OmitByType<T, Function>) => unknown;
+  [x: string]: (element: Omit<OmitByType<T, Function>, '~standard'>) => unknown;
 };
 
 export type RegleShortcutDefinition<TCustomRules extends Record<string, any> = {}> = {

--- a/packages/core/src/types/core/results.types.ts
+++ b/packages/core/src/types/core/results.types.ts
@@ -1,9 +1,18 @@
+import type { EmptyObject, IsAny, IsUnknown } from 'type-fest';
 import type { MaybeRef, Raw, UnwrapRef } from 'vue';
 import type {
+  $InternalRegleCollectionErrors,
+  $InternalRegleCollectionIssues,
+  $InternalRegleErrorTree,
+  $InternalRegleIssuesTree,
   CustomRulesDeclarationTree,
+  RegleCollectionErrors,
   RegleCollectionRuleDecl,
+  RegleErrorTree,
+  RegleFieldIssue,
   RegleFieldStatus,
   RegleFormPropertyType,
+  RegleIssuesTree,
   ReglePartialRuleTree,
   RegleRoot,
   RegleRuleDecl,
@@ -20,7 +29,6 @@ import type {
   MaybeOutput,
   Prettify,
 } from '../utils';
-import type { IsAny, IsUnknown } from 'type-fest';
 
 export type PartialFormState<TState extends Record<string, any>> = [unknown] extends [TState]
   ? {}
@@ -79,6 +87,48 @@ export type RegleResult<
             : unknown;
     };
 
+export type RegleNestedResult<
+  Data extends Record<string, any> | unknown,
+  TRules extends ReglePartialRuleTree<any> | RegleFormPropertyType<any>,
+> = RegleResult<Data, TRules> &
+  (
+    | {
+        valid: false;
+        issues: RegleIssuesTree<Data>;
+        errors: RegleErrorTree<Data>;
+      }
+    | {
+        valid: true;
+        issues: EmptyObject;
+        errors: EmptyObject;
+      }
+  );
+
+export type RegleCollectionResult<
+  Data extends any[],
+  TRules extends ReglePartialRuleTree<any> | RegleFormPropertyType<any>,
+> = RegleResult<Data, TRules> &
+  (
+    | {
+        valid: false;
+        issues: RegleCollectionErrors<Data, true>;
+        errors: RegleCollectionErrors<Data>;
+      }
+    | {
+        valid: true;
+        issues: EmptyObject;
+        errors: EmptyObject;
+      }
+  );
+
+export type RegleFieldResult<
+  Data extends any,
+  TRules extends ReglePartialRuleTree<any> | RegleFormPropertyType<any>,
+> = RegleResult<Data, TRules> & {
+  issues: RegleFieldIssue<TRules>[];
+  errors: string[];
+};
+
 /**
  * Infer safe output from any `r$` instance
  *
@@ -95,7 +145,12 @@ export type InferSafeOutput<
       ? SafeFieldProperty<TState, TRules>
       : never;
 
-export type $InternalRegleResult = { valid: boolean; data: any };
+export type $InternalRegleResult = {
+  valid: boolean;
+  data: any;
+  errors: $InternalRegleErrorTree | $InternalRegleCollectionErrors | string[];
+  issues: $InternalRegleIssuesTree | $InternalRegleCollectionIssues | RegleFieldIssue[];
+};
 
 export type DeepSafeFormState<
   TState extends Record<string, any>,

--- a/packages/core/src/types/rules/compatibility.rules.ts
+++ b/packages/core/src/types/rules/compatibility.rules.ts
@@ -16,7 +16,7 @@ export interface SuperCompatibleRegle {
 /** Supports both core Regle and schemas Regle for Zod/Valibot */
 export type SuperCompatibleRegleRoot = SuperCompatibleRegleStatus & {
   $groups?: { [x: string]: RegleValidationGroupOutput };
-  $validate: () => Promise<SuperCompatibleRegleResult>;
+  $validate: (...args: any[]) => Promise<SuperCompatibleRegleResult>;
 };
 
 export type SuperCompatibleRegleResult = $InternalRegleResult;

--- a/packages/core/src/types/rules/rule.status.types.ts
+++ b/packages/core/src/types/rules/rule.status.types.ts
@@ -38,13 +38,6 @@ import type {
   ResetOptions,
 } from '..';
 
-export interface RegleStandardSchema<Input = unknown, Output = Input> extends StandardSchemaV1<Input, Output> {
-  readonly '~standard': Omit<StandardSchemaV1.Props<Input, Output>, 'version' | 'vendor'> & {
-    version: 1;
-    vendor: 'regle';
-  };
-}
-
 /**
  * @public
  */
@@ -307,7 +300,7 @@ export interface $InternalRegleFieldStatus extends $InternalRegleCommonStatus {
 /**
  * @public
  */
-export interface RegleCommonStatus<TValue = any> extends RegleStandardSchema<TValue> {
+export interface RegleCommonStatus<TValue = any> extends StandardSchemaV1<TValue> {
   /** Indicates whether the field is invalid. It becomes true if any associated rules return false. */
   readonly $invalid: boolean;
   /**

--- a/packages/core/src/types/utils/infer.types.ts
+++ b/packages/core/src/types/utils/infer.types.ts
@@ -12,9 +12,17 @@ export type InferInput<
   IsUnion<UnwrapSimple<TRules>> extends true
     ? InferTupleUnionInput<UnionToTuple<UnwrapSimple<TRules>>>[number]
     : TMarkMaybe extends true
-      ? Prettify<{
-          [K in keyof UnwrapSimple<TRules>]?: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
-        }>
+      ? Prettify<
+          {
+            [K in keyof UnwrapSimple<TRules> as UnwrapSimple<TRules>[K] extends MaybeRef<RegleRuleDecl<any, any>>
+              ? K
+              : never]?: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
+          } & {
+            [K in keyof UnwrapSimple<TRules> as UnwrapSimple<TRules>[K] extends MaybeRef<RegleRuleDecl<any, any>>
+              ? never
+              : K]: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
+          }
+        >
       : Prettify<{
           [K in keyof UnwrapSimple<TRules>]: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
         }>;

--- a/packages/core/src/types/utils/infer.types.ts
+++ b/packages/core/src/types/utils/infer.types.ts
@@ -2,30 +2,34 @@ import type { IsUnion, UnionToTuple } from 'type-fest';
 import type { MaybeRef, UnwrapRef } from 'vue';
 import type { RegleCollectionEachRules, ReglePartialRuleTree, RegleRuleDecl, RegleRuleDefinition } from '../rules';
 import type { ExtractFromGetter, Prettify, UnwrapSimple } from './misc.types';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 export type InferInput<
   TRules extends
     | MaybeRef<ReglePartialRuleTree<Record<string, any>, any>>
-    | ((state: any) => ReglePartialRuleTree<Record<string, any>, any>),
+    | ((state: any) => ReglePartialRuleTree<Record<string, any>, any>)
+    | MaybeRef<StandardSchemaV1<any>>,
   TMarkMaybe extends boolean = true,
 > =
-  IsUnion<UnwrapSimple<TRules>> extends true
-    ? InferTupleUnionInput<UnionToTuple<UnwrapSimple<TRules>>>[number]
-    : TMarkMaybe extends true
-      ? Prettify<
-          {
-            [K in keyof UnwrapSimple<TRules> as UnwrapSimple<TRules>[K] extends MaybeRef<RegleRuleDecl<any, any>>
-              ? K
-              : never]?: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
-          } & {
-            [K in keyof UnwrapSimple<TRules> as UnwrapSimple<TRules>[K] extends MaybeRef<RegleRuleDecl<any, any>>
-              ? never
-              : K]: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
-          }
-        >
-      : Prettify<{
-          [K in keyof UnwrapSimple<TRules>]: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
-        }>;
+  TRules extends MaybeRef<StandardSchemaV1<infer State>>
+    ? State
+    : IsUnion<UnwrapSimple<TRules>> extends true
+      ? InferTupleUnionInput<UnionToTuple<UnwrapSimple<TRules>>>[number]
+      : TMarkMaybe extends true
+        ? Prettify<
+            {
+              [K in keyof UnwrapSimple<TRules> as UnwrapSimple<TRules>[K] extends MaybeRef<RegleRuleDecl<any, any>>
+                ? K
+                : never]?: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
+            } & {
+              [K in keyof UnwrapSimple<TRules> as UnwrapSimple<TRules>[K] extends MaybeRef<RegleRuleDecl<any, any>>
+                ? never
+                : K]: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
+            }
+          >
+        : Prettify<{
+            [K in keyof UnwrapSimple<TRules>]: ProcessInputChildren<UnwrapSimple<TRules>[K], TMarkMaybe>;
+          }>;
 
 type ProcessInputChildren<TRule extends unknown, TMarkMaybe extends boolean> = TRule extends {
   $each: RegleCollectionEachRules<any, any>;

--- a/packages/schemas/src/core/useRegleSchema.ts
+++ b/packages/schemas/src/core/useRegleSchema.ts
@@ -192,6 +192,8 @@ export function createUseRegleSchemaComposable<TShortcuts extends RegleShortcutD
         return {
           valid: !result.issues?.length,
           data: processedState.value,
+          errors: {},
+          issues: {},
         };
       } catch (e) {
         return Promise.reject(e);

--- a/packages/schemas/src/types/core.types.ts
+++ b/packages/schemas/src/types/core.types.ts
@@ -44,14 +44,16 @@ export type RegleSingleFieldSchema<
   r$: Raw<
     RegleSchemaFieldStatus<TState, TSchema, TShortcuts> & {
       /** Sets all properties as dirty, triggering all rules. It returns a promise that will either resolve to false or a type safe copy of your form state. Values that had the required rule will be transformed into a non-nullable value (type only). */
-      $validate: () => Promise<RegleSchemaResult<TSchema>>;
+      $validate: (
+        forceValues?: TSchema extends EmptyObject ? any : HasNamedKeys<TSchema> extends true ? TSchema : any
+      ) => Promise<RegleSchemaResult<TSchema>>;
     }
   >;
 } & TAdditionalReturnProperties;
 
 export type RegleSchemaResult<TSchema extends unknown> =
-  | { valid: false; data: PartialDeep<TSchema> }
-  | { valid: true; data: TSchema };
+  | { valid: false; data: PartialDeep<TSchema>; issues: RegleIssuesTree<TSchema>; errors: RegleErrorTree<TSchema> }
+  | { valid: true; data: TSchema; issues: EmptyObject; errors: EmptyObject };
 
 type ProcessNestedFields<
   TState extends Record<string, any>,
@@ -109,7 +111,9 @@ export type RegleSchemaStatus<
   (IsRoot extends true
     ? {
         /** Sets all properties as dirty, triggering all rules. It returns a promise that will either resolve to false or a type safe copy of your form state. Values that had the required rule will be transformed into a non-nullable value (type only). */
-        $validate: () => Promise<RegleSchemaResult<TSchema>>;
+        $validate: (
+          forceValues?: TSchema extends EmptyObject ? (HasNamedKeys<TSchema> extends true ? TSchema : any) : TSchema
+        ) => Promise<RegleSchemaResult<TSchema>>;
       }
     : {}) &
   ([TShortcuts['nested']] extends [never]

--- a/packages/schemas/src/types/options.types.ts
+++ b/packages/schemas/src/types/options.types.ts
@@ -1,4 +1,4 @@
-export type $InternalRegleResult = { valid: boolean; data: any };
+export type $InternalRegleResult = { valid: boolean; data: any; errors: any; issues: any };
 
 export type RegleSchemaBehaviourOptions = {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@standard-schema/spec':
+        specifier: 1.0.0
+        version: 1.0.0
       pinia:
         specifier: '>=2.2.5'
         version: 2.3.0(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
@@ -625,6 +628,9 @@ importers:
       '@regle/schemas':
         specifier: workspace:*
         version: link:../packages/schemas
+      '@standard-schema/spec':
+        specifier: 1.0.0
+        version: 1.0.0
       '@vue/compiler-dom':
         specifier: 'catalog:'
         version: 3.5.21
@@ -1132,20 +1138,11 @@ packages:
       search-insights:
         optional: true
 
-  '@emnapi/core@1.4.5':
-    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
-
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
 
-  '@emnapi/runtime@1.4.5':
-    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
-
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
-
-  '@emnapi/wasi-threads@1.0.4':
-    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -1751,9 +1748,6 @@ packages:
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@napi-rs/wasm-runtime@1.0.3':
-    resolution: {integrity: sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==}
 
   '@napi-rs/wasm-runtime@1.0.5':
     resolution: {integrity: sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==}
@@ -3000,9 +2994,6 @@ packages:
 
   '@tsconfig/node22@22.0.1':
     resolution: {integrity: sha512-VkgOa3n6jvs1p+r3DiwBqeEwGAwEvnVCg/hIjiANl5IEcqP3G0u5m8cBJspe1t9qjZRlZ7WFgqq5bJrGdgAKMg==}
-
-  '@tybys/wasm-util@0.10.0':
-    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -8347,29 +8338,13 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@emnapi/core@1.4.5':
-    dependencies:
-      '@emnapi/wasi-threads': 1.0.4
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.5.0':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.4.5':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.5.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -8614,7 +8589,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8628,7 +8603,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -8783,13 +8758,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@napi-rs/wasm-runtime@1.0.3':
-    dependencies:
-      '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
-      '@tybys/wasm-util': 0.10.0
-    optional: true
 
   '@napi-rs/wasm-runtime@1.0.5':
     dependencies:
@@ -9407,7 +9375,7 @@ snapshots:
 
   '@oxc-minify/binding-wasm32-wasi@0.87.0':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.3
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
   '@oxc-minify/binding-win32-arm64-msvc@0.87.0':
@@ -9454,7 +9422,7 @@ snapshots:
 
   '@oxc-parser/binding-wasm32-wasi@0.87.0':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.3
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
   '@oxc-parser/binding-win32-arm64-msvc@0.87.0':
@@ -9509,7 +9477,7 @@ snapshots:
 
   '@oxc-transform/binding-wasm32-wasi@0.87.0':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.3
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
   '@oxc-transform/binding-win32-arm64-msvc@0.87.0':
@@ -9749,7 +9717,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.34':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.3
+      '@napi-rs/wasm-runtime': 1.0.5
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-beta.38':
@@ -10160,11 +10128,6 @@ snapshots:
   '@tsconfig/node20@20.1.6': {}
 
   '@tsconfig/node22@22.0.1': {}
-
-  '@tybys/wasm-util@0.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -11798,7 +11761,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1

--- a/tests/fixtures/validations.fixtures.ts
+++ b/tests/fixtures/validations.fixtures.ts
@@ -57,6 +57,7 @@ export function nestedRefObjectValidation(): ReturnRegleType {
       collection: [{ name: 0 as number | null }],
     },
   });
+
   return useRegle(
     form,
     () =>

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,7 @@
     "@regle/core": "workspace:*",
     "@regle/rules": "workspace:*",
     "@regle/schemas": "workspace:*",
+    "@standard-schema/spec": "1.0.0",
     "@vue/compiler-dom": "catalog:",
     "@vue/reactivity": "catalog:",
     "arktype": "catalog:",

--- a/tests/unit/schemas/unions/schema-unions.spec.ts
+++ b/tests/unit/schemas/unions/schema-unions.spec.ts
@@ -10,11 +10,12 @@ import {
 } from '../../../utils/validations.utils';
 import { MyEnum, valibotUnionsFixture } from './fixtures/valibot.fixture';
 import { zodUnionsFixture } from './fixtures/zod.fixture';
+import { zod4UnionsFixture } from './fixtures/zod4.fixture';
 
 describe.each([
-  ['valibot', valibotUnionsFixture],
   ['zod', zodUnionsFixture],
-  // ['zod4', zod4UnionsFixture],
+  ['valibot', valibotUnionsFixture],
+  ['zod4', zod4UnionsFixture],
 ])('schemas (%s) - unions types', (name, regleSchema) => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -25,6 +26,7 @@ describe.each([
   });
 
   it('should behave correctly with unions, nums, and discriminated unions', async () => {
+    // @ts-expect-error Invalid InferInput type on Standard Schema
     const { vm } = createRegleComponent(regleSchema);
 
     shouldBeInvalidField(vm.r$.enum);

--- a/tests/unit/useRegle/errors/flatErrors.spec.ts
+++ b/tests/unit/useRegle/errors/flatErrors.spec.ts
@@ -81,8 +81,8 @@ describe('flatErrors', () => {
       { message: 'This field is required', path: ['email'] },
       { message: 'This field is required', path: ['user', 'firstName'] },
       { message: 'This field is required', path: ['user', 'nested', 'child'] },
-      { message: 'This field is required', path: ['user', 'nested', 'collection', '0', 'name'] },
-      { message: 'This field is required', path: ['contacts', '0', 'name'] },
+      { message: 'This field is required', path: ['user', 'nested', 'collection', 0, 'name'] },
+      { message: 'This field is required', path: ['contacts', 0, 'name'] },
     ]);
 
     vm.r$.$value.email = 'foo';
@@ -95,8 +95,8 @@ describe('flatErrors', () => {
       { message: 'The value length should be at least 5', path: ['email'] },
       { message: 'This field is required', path: ['user', 'firstName'] },
       { message: 'This field is required', path: ['user', 'nested', 'child'] },
-      { message: 'This field is required', path: ['user', 'nested', 'collection', '0', 'name'] },
-      { message: 'This field is required', path: ['contacts', '0', 'name'] },
+      { message: 'This field is required', path: ['user', 'nested', 'collection', 0, 'name'] },
+      { message: 'This field is required', path: ['contacts', 0, 'name'] },
     ]);
   });
 });

--- a/tests/unit/useRegle/refine-rules/InferInput.spec-d.ts
+++ b/tests/unit/useRegle/refine-rules/InferInput.spec-d.ts
@@ -39,8 +39,8 @@ describe('InferInput should correctly infer state type from a rules object', () 
     string?: MaybeInput<string>;
     unions?: MaybeInput<string | Date>;
     overrideRefine?: MaybeInput<string | number>;
-    collection?: { name?: MaybeInput<string> }[];
-    super?: { nested?: { object?: { firstName?: MaybeInput<number | string> } } };
+    collection: { name?: MaybeInput<string> }[];
+    super: { nested: { object: { firstName?: MaybeInput<number | string> } } };
   };
 
   expectTypeOf<InferInput<typeof rules>>().toEqualTypeOf<ExpectedState>();

--- a/tests/unit/useRegle/refine-rules/InferInput.spec-d.ts
+++ b/tests/unit/useRegle/refine-rules/InferInput.spec-d.ts
@@ -1,4 +1,4 @@
-import { refineRules, type InferInput, type MaybeInput } from '@regle/core';
+import { refineRules, useRules, type InferInput, type MaybeInput } from '@regle/core';
 import { dateBefore, number, numeric, required, string, type } from '@regle/rules';
 import { computed, ref } from 'vue';
 
@@ -31,6 +31,8 @@ describe('InferInput should correctly infer state type from a rules object', () 
     overrideRefine: { type: type<number>() },
   }));
 
+  const schema = useRules(rules);
+
   type ExpectedState = {
     firstName?: unknown;
     lastName?: unknown;
@@ -46,6 +48,7 @@ describe('InferInput should correctly infer state type from a rules object', () 
   expectTypeOf<InferInput<typeof rules>>().toEqualTypeOf<ExpectedState>();
   expectTypeOf<InferInput<typeof refRules>>().toEqualTypeOf<ExpectedState>();
   expectTypeOf<InferInput<typeof computedRules>>().toEqualTypeOf<ExpectedState>();
+  expectTypeOf<InferInput<typeof schema>>().toEqualTypeOf<ExpectedState>();
   expectTypeOf<InferInput<typeof refinedRules>>().toExtend<
     ExpectedState & {
       overrideRefine?: MaybeInput<number>;

--- a/tests/unit/useRules/useRules.nested.spec.ts
+++ b/tests/unit/useRules/useRules.nested.spec.ts
@@ -115,7 +115,7 @@ describe('nested validations', () => {
 
     const result = await schema['~standard'].validate({
       level0: { level1: { name: '' }, level2: '' },
-      collection: [{ name: '' }],
+      collection: [{ name: '' }, { name: 'foo' }, { name: '' }],
       testDate: new Date(),
       testFile: emptyFile,
     });
@@ -124,6 +124,7 @@ describe('nested validations', () => {
       { message: 'This field is required', path: ['level0', 'level1', 'name'] },
       { message: 'This field is required', path: ['level0', 'level2'] },
       { message: 'This field is required', path: ['collection', 0, 'name'] },
+      { message: 'This field is required', path: ['collection', 2, 'name'] },
       { message: 'The date must be before 2/1/00', path: ['testDate'] },
       { message: 'This field is required', path: ['testFile'] },
     ]);

--- a/tests/unit/useRules/useRules.nested.spec.ts
+++ b/tests/unit/useRules/useRules.nested.spec.ts
@@ -1,0 +1,140 @@
+import { useRules } from '@regle/core';
+import { dateAfter, dateBefore, required, string, type } from '@regle/rules';
+import { addDays } from 'date-fns';
+import { createRegleComponent } from '../../utils/test.utils';
+import { shouldBeErrorField, shouldBeInvalidField, shouldBeValidField } from '../../utils/validations.utils';
+
+const emptyFile = new File([''], 'empty.png');
+Object.defineProperty(emptyFile, 'size', { value: 0, configurable: true });
+
+const normalFile = new File([''], 'normal.png');
+Object.defineProperty(normalFile, 'size', { value: 1024 * 1024, configurable: true });
+
+describe('nested validations', () => {
+  function nestedCollectionRules() {
+    const rules = {
+      level0: {
+        level1: { name: { required, string } },
+        level2: { required, string },
+      },
+      collection: {
+        $each: {
+          name: { required, string },
+        },
+      },
+      testDate: { required, dateAfter: dateAfter(addDays(new Date(), 1)) },
+      testFile: { required, type: type<File>() },
+    };
+    return { r$: useRules(rules) };
+  }
+
+  it('should behave correctly with nested arrays', async () => {
+    const { vm } = createRegleComponent(nestedCollectionRules);
+
+    shouldBeInvalidField(vm.r$.level0);
+    shouldBeInvalidField(vm.r$.level0.level1);
+    shouldBeInvalidField(vm.r$.level0.level1.name);
+    shouldBeInvalidField(vm.r$.testDate);
+    shouldBeInvalidField(vm.r$.collection.$each[0].name);
+
+    vm.r$.$value.level0.level1.name = 'Hello';
+    await vm.$nextTick();
+
+    shouldBeInvalidField(vm.r$.level0);
+
+    vm.r$.$value = {
+      level0: {
+        level1: {
+          name: 'foobar',
+        },
+        level2: '',
+      },
+      collection: [{ name: '' }],
+      testDate: new Date(),
+      testFile: emptyFile,
+    };
+
+    await vm.$nextTick();
+
+    shouldBeErrorField(vm.r$.level0);
+    shouldBeValidField(vm.r$.level0.level1);
+    shouldBeValidField(vm.r$.level0.level1.name);
+    shouldBeErrorField(vm.r$.testDate);
+    shouldBeErrorField(vm.r$.testFile);
+    shouldBeErrorField(vm.r$.collection);
+    shouldBeErrorField(vm.r$.collection.$each[0].name);
+
+    vm.r$.$reset({ toInitialState: true });
+
+    await vm.$nextTick();
+
+    shouldBeInvalidField(vm.r$.level0);
+    shouldBeInvalidField(vm.r$.level0.level1);
+    shouldBeInvalidField(vm.r$.level0.level1.name);
+    shouldBeInvalidField(vm.r$.testDate);
+    shouldBeInvalidField(vm.r$.testFile);
+
+    vm.r$.$value = {
+      level0: {
+        level1: {
+          name: 'foobar',
+        },
+        level2: 'Foo',
+      },
+      collection: [{ name: 'foo' }],
+      testDate: addDays(new Date(), 3),
+      testFile: normalFile,
+    };
+    await vm.$nextTick();
+
+    shouldBeValidField(vm.r$.level0);
+    shouldBeValidField(vm.r$.level0.level1);
+    shouldBeValidField(vm.r$.level0.level1.name);
+    shouldBeValidField(vm.r$.testDate);
+    shouldBeValidField(vm.r$.testFile);
+    shouldBeValidField(vm.r$.collection);
+    shouldBeValidField(vm.r$.collection.$each[0].name);
+  });
+
+  it('should implement standard schema v1 issues', async () => {
+    const rules = {
+      level0: {
+        level1: { name: { required, string } },
+        level2: { required, string },
+      },
+      collection: {
+        $each: {
+          name: { required, string },
+        },
+      },
+      testDate: { required, dateAfter: dateBefore(new Date(2000, 1, 1), { allowEqual: false }) },
+      testFile: { required, type: type<File>() },
+    };
+
+    const schema = useRules(rules);
+
+    const result = await schema['~standard'].validate({
+      level0: { level1: { name: '' }, level2: '' },
+      collection: [{ name: '' }],
+      testDate: new Date(),
+      testFile: emptyFile,
+    });
+
+    expect(result.issues).toStrictEqual([
+      { message: 'This field is required', path: ['level0', 'level1', 'name'] },
+      { message: 'This field is required', path: ['level0', 'level2'] },
+      { message: 'This field is required', path: ['collection', '0', 'name'] },
+      { message: 'The date must be before 2/1/00', path: ['testDate'] },
+      { message: 'This field is required', path: ['testFile'] },
+    ]);
+
+    const result2 = await schema['~standard'].validate({
+      level0: { level1: { name: 'foobar' }, level2: 'Foo' },
+      collection: [{ name: 'foo' }],
+      testDate: new Date(1999, 1, 1),
+      testFile: normalFile,
+    });
+
+    expect(result2.issues).toStrictEqual([]);
+  });
+});

--- a/tests/unit/useRules/useRules.nested.spec.ts
+++ b/tests/unit/useRules/useRules.nested.spec.ts
@@ -123,7 +123,7 @@ describe('nested validations', () => {
     expect(result.issues).toStrictEqual([
       { message: 'This field is required', path: ['level0', 'level1', 'name'] },
       { message: 'This field is required', path: ['level0', 'level2'] },
-      { message: 'This field is required', path: ['collection', '0', 'name'] },
+      { message: 'This field is required', path: ['collection', 0, 'name'] },
       { message: 'The date must be before 2/1/00', path: ['testDate'] },
       { message: 'This field is required', path: ['testFile'] },
     ]);

--- a/tests/unit/useRules/useRules.schema.spec.ts
+++ b/tests/unit/useRules/useRules.schema.spec.ts
@@ -1,0 +1,20 @@
+import { useRules } from '@regle/core';
+import { required, string } from '@regle/rules';
+import { useRegleSchema } from '@regle/schemas';
+import { nextTick } from 'vue';
+import { shouldBePristineField, shouldBeValidField } from '../../utils/validations.utils';
+
+describe('useRules schema', () => {
+  it('should be able to use itself as aschema', async () => {
+    const schema = useRules({ username: { required, string } });
+
+    const { r$ } = useRegleSchema({ username: '' }, schema);
+
+    shouldBePristineField(r$.username);
+
+    r$.$value.username = 'foo';
+    await nextTick();
+
+    shouldBeValidField(r$.username);
+  });
+});


### PR DESCRIPTION
feat: use Standard Schema `~standard` property on any nested schema property
feat: `useRules` for a stateless and functionnal use of Regle
feat: `forceValues` parameter in `$validate` method. Patch the state before validating

BREAKING CHANGE: `flatErrors` now follow standard Issue format, `path` is now Array (ex: `path: "foo.0.bar"` -> `path: ["foo", 0, "bar"]`