### PR TITLE
fix: devtools inject symbol

### DIFF
--- a/packages/core/src/devtools/registry.ts
+++ b/packages/core/src/devtools/registry.ts
@@ -135,7 +135,7 @@ export function registerRegleInstance(r$: SuperCompatibleRegleRoot, options?: { 
     if (isTestEnv) {
       return;
     }
-    const regleVersion: string | undefined = inject(regleSymbol);
+    const regleVersion: string | undefined = inject(regleSymbol, undefined);
 
     if (
       !regleVersion &&


### PR DESCRIPTION
When using regle it shows injection warning, because the devtools inject call does not provide default value.
```
[Vue warn]: injection "Symbol(regle)" not found. 
```

This PR adds a default value so that the warning is not printed.