### PR TITLE
fix(mcp-server): add bugs.url metadata field to package.json

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -65,5 +65,8 @@
     "tsdown": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"
+  },
+  "bugs": {
+    "url": "https://github.com/victorgarciaesgi/regle/issues"
   }
 }


### PR DESCRIPTION
This adds the missing `bugs.url` field to the package.json for @regle/mcp-server npm package.

Closes charles-openclaw/charles-microbounties#346