### PR TITLE
Fix stale validation overwrite in async processing

### DIFF
--- a/packages/core/src/core/useRegle/root/createReactiveRuleStatus.ts
+++ b/packages/core/src/core/useRegle/root/createReactiveRuleStatus.ts
@@ -67,6 +67,13 @@ export function createReactiveRuleStatus({
   });
   const $maybePending = ref(false);
 
+  /**
+   * Monotonic token identifying the latest validation run.
+   * Any async run that resolves after a newer run has started is considered stale
+   * and must not write its result, to avoid an outdated value overwriting a fresh one.
+   */
+  let $lastParseId = 0;
+
   const { $pending, $valid, $metadata, $validating } = storage.trySetRuleStatusRef(`${cachePath}.${ruleKey}`);
 
   function $watch() {
@@ -229,7 +236,7 @@ export function createReactiveRuleStatus({
     }
   }
 
-  async function computeAsyncResult(): Promise<boolean> {
+  async function computeAsyncResult(parseId: number): Promise<boolean> {
     let ruleResult = false;
     try {
       const validator = scopeState.$validator.value;
@@ -238,7 +245,7 @@ export function createReactiveRuleStatus({
         return false;
       }
       const resultOrPromise = validator(state.value, ...scopeState.$params.value);
-      let cachedValue = state.value;
+      const cachedValue = state.value;
       updatePendingState();
       let validatorResult;
       if (resultOrPromise instanceof Promise) {
@@ -247,20 +254,26 @@ export function createReactiveRuleStatus({
         validatorResult = resultOrPromise;
       }
 
-      if (state.value !== cachedValue) {
-        return true;
+      // A newer validation run was started (or the value changed) while this one was
+      // pending. This result is stale: leave the shared state untouched so it cannot
+      // overwrite the result of the latest run.
+      if (parseId !== $lastParseId || state.value !== cachedValue) {
+        return $valid.value;
       }
       if (typeof validatorResult === 'boolean') {
         ruleResult = validatorResult;
       } else {
-        const { $valid, ...rest } = validatorResult;
-        ruleResult = $valid;
+        const { $valid: $validResult, ...rest } = validatorResult;
+        ruleResult = $validResult;
         $metadata.value = rest;
       }
     } catch {
       ruleResult = false;
     } finally {
-      $pending.value = false;
+      // Only the latest run is allowed to clear the shared pending flag.
+      if (parseId === $lastParseId) {
+        $pending.value = false;
+      }
     }
 
     return ruleResult;
@@ -300,6 +313,7 @@ export function createReactiveRuleStatus({
   }
 
   async function $parse(): Promise<boolean> {
+    const parseId = ++$lastParseId;
     try {
       $validating.value = true;
 
@@ -307,18 +321,26 @@ export function createReactiveRuleStatus({
       $maybePending.value = true;
 
       if (isRuleDef(rule.value) && rule.value._async) {
-        ruleResult = await computeAsyncResult();
+        ruleResult = await computeAsyncResult(parseId);
       } else {
         const validator = scopeState.$validator.value;
         ruleResult = computeSyncResult(validator);
+      }
+      // A newer validation run superseded this one while it was pending: don't write
+      // the stale result over the latest one.
+      if (parseId !== $lastParseId) {
+        return $valid.value;
       }
       $valid.value = ruleResult;
       return ruleResult;
     } catch {
       return false;
     } finally {
-      $validating.value = false;
-      $maybePending.value = false;
+      // Only the latest run owns the shared validating/pending flags.
+      if (parseId === $lastParseId) {
+        $validating.value = false;
+        $maybePending.value = false;
+      }
     }
   }
 
@@ -339,6 +361,8 @@ export function createReactiveRuleStatus({
   }
 
   function $reset() {
+    // Invalidate any in-flight async run so it cannot write after the reset.
+    $lastParseId++;
     $valid.value = true;
     $metadata.value = {};
     $pending.value = false;

--- a/packages/core/src/core/useRegle/root/createReactiveRuleStatus.ts
+++ b/packages/core/src/core/useRegle/root/createReactiveRuleStatus.ts
@@ -245,7 +245,7 @@ export function createReactiveRuleStatus({
         return false;
       }
       const resultOrPromise = validator(state.value, ...scopeState.$params.value);
-      const cachedValue = state.value;
+      let cachedValue = state.value;
       updatePendingState();
       let validatorResult;
       if (resultOrPromise instanceof Promise) {
@@ -254,17 +254,16 @@ export function createReactiveRuleStatus({
         validatorResult = resultOrPromise;
       }
 
-      // A newer validation run was started (or the value changed) while this one was
-      // pending. This result is stale: leave the shared state untouched so it cannot
-      // overwrite the result of the latest run.
+      // A newer run started (or the value changed) while pending: this result is stale,
+      // keep the current valid state so it can't overwrite the latest run's result.
       if (parseId !== $lastParseId || state.value !== cachedValue) {
         return $valid.value;
       }
       if (typeof validatorResult === 'boolean') {
         ruleResult = validatorResult;
       } else {
-        const { $valid: $validResult, ...rest } = validatorResult;
-        ruleResult = $validResult;
+        const { $valid, ...rest } = validatorResult;
+        ruleResult = $valid;
         $metadata.value = rest;
       }
     } catch {
@@ -326,8 +325,7 @@ export function createReactiveRuleStatus({
         const validator = scopeState.$validator.value;
         ruleResult = computeSyncResult(validator);
       }
-      // A newer validation run superseded this one while it was pending: don't write
-      // the stale result over the latest one.
+      // A newer run superseded this one while pending: don't overwrite its result.
       if (parseId !== $lastParseId) {
         return $valid.value;
       }

--- a/tests/unit/useRegle/async/asyncRules.raceCondition.spec.ts
+++ b/tests/unit/useRegle/async/asyncRules.raceCondition.spec.ts
@@ -215,4 +215,55 @@ describe('useRegle async rules race conditions', () => {
     expect(vm.r$.$pending).toBe(false);
     expect(vm.r$.$rules.slowWhenValid.$valid).toBe(false);
   });
+
+  /**
+   * Same race, but the validator returns a metadata object. The stale run must not
+   * leave its metadata behind paired with the latest run's validity.
+   */
+  function metadataRaceValidation() {
+    const slowWhenValid = createRule({
+      async validator(value: Maybe<string>) {
+        if (!isFilled(value)) {
+          return { $valid: true, label: value } as const;
+        }
+        await timeout(value === 'valid' ? 2000 : 200);
+        return { $valid: value === 'valid', label: value };
+      },
+      message: 'Invalid value',
+    });
+
+    return useRegle(ref(''), {
+      slowWhenValid,
+    });
+  }
+
+  it('should not keep stale metadata when a slower previous validation resolves last', async () => {
+    const { vm } = createRegleComponent(metadataRaceValidation);
+
+    vm.r$.$value = 'valid';
+    await vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    expect(vm.r$.$pending).toBe(true);
+
+    vm.r$.$value = 'invalid';
+    await vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+
+    expect(vm.r$.$rules.slowWhenValid.$valid).toBe(false);
+    expect(vm.r$.$rules.slowWhenValid.$metadata.label).toBe('invalid');
+
+    // The stale "valid" run resolves last: neither its validity nor its metadata
+    // may overwrite the latest "invalid" result.
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushPromises();
+
+    expect(vm.r$.$rules.slowWhenValid.$valid).toBe(false);
+    expect(vm.r$.$rules.slowWhenValid.$metadata.label).toBe('invalid');
+  });
 });

--- a/tests/unit/useRegle/async/asyncRules.raceCondition.spec.ts
+++ b/tests/unit/useRegle/async/asyncRules.raceCondition.spec.ts
@@ -1,0 +1,218 @@
+import { flushPromises } from '@vue/test-utils';
+import type { Maybe } from '@regle/core';
+import { createRule, useRegle } from '@regle/core';
+import { isFilled } from '@regle/rules';
+import { ref } from 'vue';
+import { createRegleComponent } from '../../../utils/test.utils';
+import { timeout } from '../../../utils';
+
+/**
+ * Regression tests for the async validation race condition where a value changed
+ * while a previous async validation is still pending could end up being reported
+ * with the (stale) result of that previous validation.
+ */
+describe('useRegle async rules race conditions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * The "valid" value resolves slowly, every other value resolves quickly.
+   * This forces the previous (valid) validation to resolve AFTER the new
+   * (invalid) one, which is the exact ordering that triggered the bug.
+   */
+  function raceValidation() {
+    const slowWhenValid = createRule({
+      async validator(value) {
+        if (!isFilled(value)) {
+          return true;
+        }
+        if (value === 'valid') {
+          await timeout(2000);
+          return true;
+        }
+        await timeout(200);
+        return false;
+      },
+      message: 'Invalid value',
+    });
+
+    return useRegle(ref(''), {
+      slowWhenValid,
+    });
+  }
+
+  it('should not validate a stale value when a slower previous validation resolves last', async () => {
+    const { vm } = createRegleComponent(raceValidation);
+
+    // Type the valid (slow) value first.
+    vm.r$.$value = 'valid';
+    await vm.$nextTick();
+
+    // Async rules debounce by 200ms, then the slow validator (2000ms) starts.
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    expect(vm.r$.$pending).toBe(true);
+
+    // Before it resolves, type an invalid (fast) value.
+    vm.r$.$value = 'invalid';
+    await vm.$nextTick();
+
+    // Debounce + fast validator resolves while the previous one is still pending.
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+
+    // The invalid value must already be reported as invalid.
+    expect(vm.r$.$value).toBe('invalid');
+    expect(vm.r$.$invalid).toBe(true);
+    expect(vm.r$.$error).toBe(true);
+
+    // Now let the stale "valid" validation finally resolve.
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushPromises();
+
+    // The stale "valid" result must NOT overwrite the invalid one.
+    expect(vm.r$.$value).toBe('invalid');
+    expect(vm.r$.$invalid).toBe(true);
+    expect(vm.r$.$error).toBe(true);
+  });
+
+  /**
+   * The reverse ordering: the previous (invalid) validation is slow and resolves
+   * AFTER the new (valid) one. The stale invalid result must not flip a valid value
+   * back to invalid.
+   */
+  function reverseRaceValidation() {
+    const slowWhenInvalid = createRule({
+      async validator(value: Maybe<string>) {
+        if (!isFilled(value)) {
+          return true;
+        }
+        if (value === 'valid') {
+          await timeout(200);
+          return true;
+        }
+        await timeout(2000);
+        return false;
+      },
+      message: 'Invalid value',
+    });
+
+    return useRegle(ref(''), {
+      slowWhenInvalid,
+    });
+  }
+
+  it('should not invalidate a fresh valid value when a slower previous (invalid) validation resolves last', async () => {
+    const { vm } = createRegleComponent(reverseRaceValidation);
+
+    // Type the invalid (slow) value first.
+    vm.r$.$value = 'invalid';
+    await vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    expect(vm.r$.$pending).toBe(true);
+
+    // Before it resolves, type a valid (fast) value.
+    vm.r$.$value = 'valid';
+    await vm.$nextTick();
+
+    // Debounce + fast validator resolves while the previous one is still pending.
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+
+    expect(vm.r$.$value).toBe('valid');
+    expect(vm.r$.$invalid).toBe(false);
+    expect(vm.r$.$error).toBe(false);
+
+    // Now let the stale "invalid" validation finally resolve.
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushPromises();
+
+    // The stale "invalid" result must NOT overwrite the valid one.
+    expect(vm.r$.$value).toBe('valid');
+    expect(vm.r$.$invalid).toBe(false);
+    expect(vm.r$.$error).toBe(false);
+    expect(vm.r$.$pending).toBe(false);
+  });
+
+  /**
+   * A field carrying both a sync rule and an async rule: a stale async result must
+   * not corrupt the field-level aggregation, and the shared pending flag must clear.
+   */
+  function multiRuleRaceValidation() {
+    const longEnough = createRule({
+      validator(value: Maybe<string>) {
+        if (!isFilled(value)) {
+          return true;
+        }
+        return value.length >= 3;
+      },
+      message: 'Too short',
+    });
+
+    const slowWhenValid = createRule({
+      async validator(value: Maybe<string>) {
+        if (!isFilled(value)) {
+          return true;
+        }
+        if (value === 'valid') {
+          await timeout(2000);
+          return true;
+        }
+        await timeout(200);
+        return false;
+      },
+      message: 'Invalid value',
+    });
+
+    return useRegle(ref(''), {
+      longEnough,
+      slowWhenValid,
+    });
+  }
+
+  it('should keep field aggregation correct with mixed sync + async rules when a stale async result resolves last', async () => {
+    const { vm } = createRegleComponent(multiRuleRaceValidation);
+
+    // Both the sync rule (length >= 3) and the async rule pass for 'valid'.
+    vm.r$.$value = 'valid';
+    await vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    expect(vm.r$.$pending).toBe(true);
+
+    // Switch to an invalid (fast) async value that still satisfies the sync rule.
+    vm.r$.$value = 'invalid';
+    await vm.$nextTick();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(200);
+    await flushPromises();
+
+    expect(vm.r$.$invalid).toBe(true);
+    expect(vm.r$.$error).toBe(true);
+    expect(vm.r$.$rules.longEnough.$valid).toBe(true);
+    expect(vm.r$.$rules.slowWhenValid.$valid).toBe(false);
+
+    // The stale "valid" async run resolves last and must not flip the field to valid.
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushPromises();
+
+    expect(vm.r$.$invalid).toBe(true);
+    expect(vm.r$.$error).toBe(true);
+    expect(vm.r$.$pending).toBe(false);
+    expect(vm.r$.$rules.slowWhenValid.$valid).toBe(false);
+  });
+});


### PR DESCRIPTION
Implement a mechanism to prevent stale validation results from overwriting fresh ones during asynchronous rule processing. This change addresses race conditions that occur when a new validation starts before a previous one completes.