### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete string escaping or encoding

### DIFF
--- a/ui-tests/utils/devtools.utils.ts
+++ b/ui-tests/utils/devtools.utils.ts
@@ -131,7 +131,7 @@ export class RegleInspector {
   }
 
   async expectState(key: string, value: string | boolean) {
-    const escapedKey = key.replace(/\$/g, '\\$');
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     await expect(this.state).toContainText(new RegExp(`${escapedKey}:${value}`));
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/victorgarciaesgi/regle/security/code-scanning/38](https://github.com/victorgarciaesgi/regle/security/code-scanning/38)

Use full regex-literal escaping for dynamic string parts before interpolation into `new RegExp(...)`.

Best fix here: replace the single-character `$` escaping with robust escaping of **all regex metacharacters**, including backslash, via:
```ts
key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
```
This is the standard safe pattern in JS/TS.

In `ui-tests/utils/devtools.utils.ts`, update `expectState` (lines 133–136 region) so `escapedKey` is computed with complete regex escaping. Keep behavior unchanged otherwise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
