### PR TITLE
v1.29.1

### DIFF
--- a/packages/shared/tests/debounce.spec.ts
+++ b/packages/shared/tests/debounce.spec.ts
@@ -122,6 +122,33 @@ describe('debounce', () => {
     expect(func).not.toHaveBeenCalled();
   });
 
+  it('should settle superseded calls with the result of the run that executes', async () => {
+    const func = vi.fn(async (x: number) => x * 2);
+    const debounced = debounce(func, 100);
+
+    const first = debounced(1);
+    const second = debounced(2);
+
+    vi.advanceTimersByTime(100);
+
+    await expect(first).resolves.toBe(4);
+    await expect(second).resolves.toBe(4);
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it('should settle pending calls when cancelled', async () => {
+    const func = vi.fn((x: number) => x * 2);
+    const debounced = debounce(func, 100);
+
+    const promise = debounced(1);
+    debounced.cancel();
+
+    vi.advanceTimersByTime(100);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(func).not.toHaveBeenCalled();
+  });
+
   it('should set trackDebounceRef to false when cancelled', async () => {
     const trackDebounceRef = ref(false);
     const func = vi.fn((x: number) => x * 2);

--- a/packages/shared/utils/debounce.ts
+++ b/packages/shared/utils/debounce.ts
@@ -11,23 +11,45 @@ export function debounce<T extends (...args: any[]) => any | Promise<any>>(
   wait: number,
   { immediate = false, trackDebounceRef }: { immediate?: boolean; trackDebounceRef?: Ref<boolean> } = {}
 ): DebouncedFunction<T> {
+  type PromiseHandlers = Pick<PromiseWithResolvers<any>, 'resolve' | 'reject'>;
+
   let timeout: NodeJS.Timeout | undefined;
+  /**
+   * Callers waiting on a debounced run. A new call clears the previous timer, so the
+   * superseded callers are settled together with the run that actually executes,
+   * otherwise their promises would never settle.
+   */
+  let pendingCallbacks: PromiseHandlers[] = [];
+
+  function disableDebounceRef() {
+    if (trackDebounceRef) {
+      trackDebounceRef.value = false;
+    }
+  }
+
+  function settleAll(settle: (callback: PromiseHandlers) => void) {
+    const callbacks = pendingCallbacks;
+    pendingCallbacks = [];
+    callbacks.forEach(settle);
+  }
+
+  function customResolve(value: any) {
+    settleAll((callback) => callback.resolve(value));
+    disableDebounceRef();
+  }
+
+  function customReject(reason: any) {
+    settleAll((callback) => callback.reject(reason));
+    disableDebounceRef();
+  }
+
   const debouncedFn: DebouncedFunction<T> = (...args) => {
     if (trackDebounceRef) {
       trackDebounceRef.value = true;
     }
 
-    function disableDebounceRef() {
-      if (trackDebounceRef) {
-        trackDebounceRef.value = false;
-      }
-    }
-
     return new Promise((resolve, reject) => {
-      function customResolve(value: any) {
-        resolve(value);
-        disableDebounceRef();
-      }
+      pendingCallbacks.push({ resolve, reject });
       clearTimeout(timeout);
       timeout = setTimeout(() => {
         disableDebounceRef();
@@ -36,10 +58,10 @@ export function debounce<T extends (...args: any[]) => any | Promise<any>>(
           try {
             Promise.resolve(func.apply(this, [...args] as any))
               .then(customResolve)
-              .catch((e) => reject(e))
+              .catch(customReject)
               .finally(disableDebounceRef);
           } catch (e) {
-            reject(e);
+            customReject(e);
           }
         }
       }, wait);
@@ -48,10 +70,10 @@ export function debounce<T extends (...args: any[]) => any | Promise<any>>(
         try {
           Promise.resolve(func.apply(this, [...args] as any))
             .then(customResolve)
-            .catch((e) => reject(e))
+            .catch(customReject)
             .finally(disableDebounceRef);
         } catch (e) {
-          reject(e);
+          customReject(e);
         }
       }
     });
@@ -60,9 +82,9 @@ export function debounce<T extends (...args: any[]) => any | Promise<any>>(
   debouncedFn.cancel = () => {
     clearTimeout(timeout);
     timeout = undefined;
-    if (trackDebounceRef) {
-      trackDebounceRef.value = false;
-    }
+    // The cancelled run will never execute: settle its waiters with no value rather
+    // than rejecting, as callers don't await `cancel`-able runs.
+    customResolve(undefined);
   };
 
   return debouncedFn;

--- a/tests/unit/useRegle/async/asyncRules.pipeTwoApplyIf.spec.ts
+++ b/tests/unit/useRegle/async/asyncRules.pipeTwoApplyIf.spec.ts
@@ -1,0 +1,77 @@
+import type { Maybe } from '@regle/core';
+import { createRule, useRegle } from '@regle/core';
+import { applyIf, isFilled, pipe } from '@regle/rules';
+import { computed } from 'vue';
+import { createRegleComponent } from '../../../utils/test.utils';
+import { timeout } from '../../../utils';
+
+/**
+ * Regression: `pipe( applyIf(condA, asyncA), applyIf(condB, asyncB) )` on a collection
+ * field where the FIRST applyIf is NOT applied. The skipped-but-still-debounced first
+ * rule flips `mappedResults`, which re-parses the second rule through its reactive
+ * `$params` and re-invokes its debounced validator. Before the `debounce` fix, the
+ * re-invocation orphaned the promise `$validate` was awaiting and it never settled.
+ */
+describe('pipe(two applyIf) field $validate, first rule not applied', () => {
+  function asyncA() {
+    return createRule({
+      async validator(value: Maybe<string>) {
+        if (!isFilled(value)) return true;
+        await timeout(40);
+        return value.length >= 3;
+      },
+      message: 'Too short',
+    });
+  }
+  function asyncB() {
+    return createRule({
+      async validator(value: Maybe<string>) {
+        if (!isFilled(value)) return true;
+        await timeout(40);
+        return value === 'valid';
+      },
+      message: 'Invalid value',
+    });
+  }
+
+  function watchdog<T>(p: Promise<T>, ms = 1500): Promise<T> {
+    let t: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      t = setTimeout(() => reject(new Error('TIMED OUT: $validate never settled')), ms);
+    });
+
+    return Promise.race([p.finally(() => t && clearTimeout(t)), timeoutPromise]);
+  }
+
+  function makeForm(condA: boolean) {
+    return useRegle({ items: [{ a: condA, b: true, name: '' }] }, () => ({
+      items: {
+        $each: (item) => ({
+          name: pipe(
+            applyIf(
+              computed(() => !!(item.value as any)?.a),
+              asyncA()
+            ),
+            applyIf(
+              computed(() => !!(item.value as any)?.b),
+              asyncB()
+            )
+          ),
+        }),
+      },
+    }));
+  }
+
+  it('settles when the first applyIf is NOT applied', async () => {
+    const { vm } = createRegleComponent(() => makeForm(false));
+    const field = () => vm.r$.items.$each[0].name;
+
+    field().$value = 'valid';
+    await vm.$nextTick();
+    await timeout(50); // inside the 200ms window
+
+    const result = await watchdog(field().$validate());
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
…f (#365)

## Problem

`$validate()` never settles on a field validated by `pipe()` of two async `applyIf` rules when the first rule is not applied — every rule reports `$pending: false`, but the promise stays forever pending, hanging any submit handler awaiting it.

## Root cause

`debounce()` returned a new promise per call, but a call inside the wait window ran `clearTimeout` on the pending timer — the earlier promise's `resolve`/`reject` lived only in that discarded closure and became unreachable.

`pipe` triggers exactly that: the skipped-but-still-debounced first rule flips the reactive `mappedResults`, which changes the second rule's `$params`, whose watcher re-invokes the same debounced validator. `$validate` was awaiting the orphaned promise.

`cancel()` had the same hole — it cleared the timer and left waiters unsettled.

## Fix

`packages/shared/utils/debounce.ts` tracks pending callers in a list instead of per-call closures:

- The run that executes settles **all** collected waiters with its result (rejections included).
- `cancel()` resolves pending waiters with `undefined` — rejecting would produce unhandled rejections, since no call site awaits a cancellable run.

## Tests

- `asyncRules.pipeTwoApplyIf.spec.ts` — regression test with a watchdog; fails on `main`, passes here.
- `debounce.spec.ts` — superseded calls resolve with the executing run's result; cancelled calls resolve with `undefined`.

Full unit suites pass: 1376 tests / 166 files. (Run `pnpm build` first, or `TEST_TRACE=true`, since the default run resolves `@regle/*` to `dist`.)

## Impact

Only promises that previously never settled change behavior. Affects all three `debounce` consumers: `pipe`'s async validator, `$commit`, `$setDirty`.

---------